### PR TITLE
Remove perlin*_fast functions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,9 @@ pub type Point2<T> = [T, ..2];
 pub type Point3<T> = [T, ..3];
 pub type Point4<T> = [T, ..4];
 
-fn perlin2_fast<T: Float>(seed: &Seed, point: &Point2<T>) -> T;
-fn perlin2_best<T: Float>(seed: &Seed, point: &Point2<T>) -> T;
-fn perlin3_fast<T: Float>(seed: &Seed, point: &Point3<T>) -> T;
-fn perlin3_best<T: Float>(seed: &Seed, point: &Point3<T>) -> T;
-fn perlin4_fast<T: Float>(seed: &Seed, point: &Point4<T>) -> T;
-fn perlin4_best<T: Float>(seed: &Seed, point: &Point4<T>) -> T;
+fn perlin2<T: Float>(seed: &Seed, point: &Point2<T>) -> T;
+fn perlin3<T: Float>(seed: &Seed, point: &Point3<T>) -> T;
+fn perlin4<T: Float>(seed: &Seed, point: &Point4<T>) -> T;
 
 fn simplex2<T: Float>(seed: &Seed, point: &Point2<T>) -> T;
 fn simplex3<T: Float>(seed: &Seed, point: &Point3<T>) -> T;

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -20,43 +20,25 @@
 extern crate noise;
 extern crate test;
 
-use noise::{perlin2_best, perlin3_best, perlin4_best, perlin2_fast, perlin3_fast, perlin4_fast, simplex2, simplex3, simplectic2, simplectic3, simplectic4, Seed};
+use noise::{perlin2, perlin3, perlin4, simplex2, simplex3, simplectic2, simplectic3, simplectic4, Seed};
 use test::Bencher;
 
 #[bench]
-fn bench_perlin2_best(bencher: &mut Bencher) {
+fn bench_perlin2(bencher: &mut Bencher) {
     let seed = Seed::new(0);
-    bencher.iter(|| perlin2_best(&seed, &[42.0f32, 37.0]));
+    bencher.iter(|| perlin2(&seed, &[42.0f32, 37.0]));
 }
 
 #[bench]
-fn bench_perlin3_best(bencher: &mut Bencher) {
+fn bench_perlin3(bencher: &mut Bencher) {
     let seed = Seed::new(0);
-    bencher.iter(|| perlin3_best(&seed, &[42.0f32, 37.0, 26.0]));
+    bencher.iter(|| perlin3(&seed, &[42.0f32, 37.0, 26.0]));
 }
 
 #[bench]
-fn bench_perlin4_best(bencher: &mut Bencher) {
+fn bench_perlin4(bencher: &mut Bencher) {
     let seed = Seed::new(0);
-    bencher.iter(|| perlin4_best(&seed, &[42.0f32, 37.0, 26.0, 128.0]));
-}
-
-#[bench]
-fn bench_perlin2_fast(bencher: &mut Bencher) {
-    let seed = Seed::new(0);
-    bencher.iter(|| perlin2_fast(&seed, &[42.0f32, 37.0]));
-}
-
-#[bench]
-fn bench_perlin3_fast(bencher: &mut Bencher) {
-    let seed = Seed::new(0);
-    bencher.iter(|| perlin3_fast(&seed, &[42.0f32, 37.0, 26.0]));
-}
-
-#[bench]
-fn bench_perlin4_fast(bencher: &mut Bencher) {
-    let seed = Seed::new(0);
-    bencher.iter(|| perlin4_fast(&seed, &[42.0f32, 37.0, 26.0, 128.0]));
+    bencher.iter(|| perlin4(&seed, &[42.0f32, 37.0, 26.0, 128.0]));
 }
 
 #[bench]

--- a/examples/brownian.rs
+++ b/examples/brownian.rs
@@ -19,7 +19,7 @@
 
 extern crate noise;
 
-use noise::{brownian2, brownian3, brownian4, perlin2_best, perlin3_best, perlin4_best, Seed, Point2};
+use noise::{brownian2, brownian3, brownian4, perlin2, perlin3, perlin4, Seed, Point2};
 
 mod debug {
     pub mod image;
@@ -33,13 +33,13 @@ fn main() {
 }
 
 fn brownian2_for_image(seed: &Seed, point: &Point2<f32>) -> f32 {
-    brownian2(seed, point, perlin2_best, 32.0, 4)
+    brownian2(seed, point, perlin2, 32.0, 4)
 }
 
 fn brownian3_for_image(seed: &Seed, point: &Point2<f32>) -> f32 {
-    brownian3(seed, &[point[0], point[1], 0.0], perlin3_best, 32.0, 4)
+    brownian3(seed, &[point[0], point[1], 0.0], perlin3, 32.0, 4)
 }
 
 fn brownian4_for_image(seed: &Seed, point: &Point2<f32>) -> f32 {
-    brownian4(seed, &[point[0], point[1], 0.0, 0.0], perlin4_best, 32.0, 4)
+    brownian4(seed, &[point[0], point[1], 0.0, 0.0], perlin4, 32.0, 4)
 }

--- a/examples/perlin_image.rs
+++ b/examples/perlin_image.rs
@@ -19,7 +19,7 @@
 
 extern crate noise;
 
-use noise::{perlin2_best, perlin3_best, perlin4_best, Seed, Point2};
+use noise::{perlin2, perlin3, perlin4, Seed, Point2};
 
 mod debug {
     pub mod image;
@@ -33,13 +33,13 @@ fn main() {
 }
 
 fn scaled_perlin2(seed: &Seed, point: &Point2<f32>) -> f32 {
-    perlin2_best(seed, &[point[0] / 32.0, point[1] / 32.00])
+    perlin2(seed, &[point[0] / 32.0f32, point[1] / 32.00])
 }
 
 fn scaled_perlin3(seed: &Seed, point: &Point2<f32>) -> f32 {
-    perlin3_best(seed, &[point[0] / 32.0, point[1] / 32.00, 0.0])
+    perlin3(seed, &[point[0] / 32.0f32, point[1] / 32.00, 0.0])
 }
 
 fn scaled_perlin4(seed: &Seed, point: &Point2<f32>) -> f32 {
-    perlin4_best(seed, &[point[0] / 32.0, point[1] / 32.00, 0.0, 0.0])
+    perlin4(seed, &[point[0] / 32.0f32, point[1] / 32.00, 0.0, 0.0])
 }

--- a/src/noise.rs
+++ b/src/noise.rs
@@ -17,7 +17,7 @@
 #![deny(missing_copy_implementations)]
 
 pub use seed::Seed;
-pub use perlin::{perlin2_fast, perlin2_best, perlin3_fast, perlin3_best, perlin4_fast, perlin4_best};
+pub use perlin::{perlin2, perlin3, perlin4};
 pub use simplex::{simplex2, simplex3};
 pub use simplectic::{simplectic2, simplectic3, simplectic4};
 pub use brownian::{brownian2, brownian3, brownian4};

--- a/src/perlin.rs
+++ b/src/perlin.rs
@@ -18,10 +18,7 @@ use std::num::Float;
 use {math, Seed};
 use gradients::{gradient2, gradient3, gradient4};
 
-fn perlin2<T, F>(seed: &Seed, point: &::Point2<T>, scurve: F) -> T where
-    T: Float,
-    F: Fn(T) -> T,
-{
+pub fn perlin2<T: Float>(seed: &Seed, point: &::Point2<T>) -> T {
     fn gradient<T: Float>(seed: &Seed, x_whole: int, y_whole: int, x_frac: T, y_frac: T) -> T {
         let [x, y] = gradient2::<T>(seed.get2(x_whole, y_whole));
         x_frac * x + y_frac * y
@@ -42,8 +39,8 @@ fn perlin2<T, F>(seed: &Seed, point: &::Point2<T>, scurve: F) -> T where
     let x1_frac = x0_frac - Float::one();
     let y1_frac = y0_frac - Float::one();
 
-    let x_curve = scurve(x0_frac);
-    let y_curve = scurve(y0_frac);
+    let x_curve = math::scurve5(x0_frac);
+    let y_curve = math::scurve5(y0_frac);
 
     let n0 = gradient(seed, x0_whole, y0_whole, x0_frac, y0_frac);
     let n1 = gradient(seed, x1_whole, y0_whole, x1_frac, y0_frac);
@@ -56,18 +53,7 @@ fn perlin2<T, F>(seed: &Seed, point: &::Point2<T>, scurve: F) -> T where
     math::lerp(y_curve, interpolated_x0, interpolated_x1)
 }
 
-pub fn perlin2_fast<T: Float>(seed: &Seed, point: &::Point2<T>) -> T {
-    perlin2(seed, point, math::scurve3)
-}
-
-pub fn perlin2_best<T: Float>(seed: &Seed, point: &::Point2<T>) -> T {
-    perlin2(seed, point, math::scurve5)
-}
-
-fn perlin3<T, F>(seed: &Seed, point: &::Point3<T>, scurve: F) -> T where
-    T: Float,
-    F: Fn(T) -> T,
-{
+pub fn perlin3<T: Float>(seed: &Seed, point: &::Point3<T>) -> T {
     fn gradient<T: Float>(seed: &Seed, x_whole: int, y_whole: int, z_whole: int, x_frac: T, y_frac: T, z_frac: T) -> T {
         let [x, y, z] = gradient3::<T>(seed.get3(x_whole, y_whole, z_whole));
         x_frac * x + y_frac * y + z_frac * z
@@ -93,9 +79,9 @@ fn perlin3<T, F>(seed: &Seed, point: &::Point3<T>, scurve: F) -> T where
     let y1_frac = y0_frac - Float::one();
     let z1_frac = z0_frac - Float::one();
 
-    let x_curve = scurve(x0_frac);
-    let y_curve = scurve(y0_frac);
-    let z_curve = scurve(z0_frac);
+    let x_curve = math::scurve5(x0_frac);
+    let y_curve = math::scurve5(y0_frac);
+    let z_curve = math::scurve5(z0_frac);
 
     let n0 = gradient(seed, x0_whole, y0_whole, z0_whole, x0_frac, y0_frac, z0_frac);
     let n1 = gradient(seed, x1_whole, y0_whole, z0_whole, x1_frac, y0_frac, z0_frac);
@@ -118,18 +104,7 @@ fn perlin3<T, F>(seed: &Seed, point: &::Point3<T>, scurve: F) -> T where
     math::lerp(z_curve, interpolated_y0, interpolated_y1)
 }
 
-pub fn perlin3_fast<T: Float>(seed: &Seed, point: &::Point3<T>) -> T {
-    perlin3(seed, point, math::scurve3)
-}
-
-pub fn perlin3_best<T: Float>(seed: &Seed, point: &::Point3<T>) -> T {
-    perlin3(seed, point, math::scurve5)
-}
-
-fn perlin4<T, F>(seed: &Seed, point: &::Point4<T>, scurve: F) -> T where
-    T: Float,
-    F: Fn(T) -> T,
-{
+pub fn perlin4<T: Float>(seed: &Seed, point: &::Point4<T>) -> T {
     fn gradient<T: Float>(seed: &Seed, x_whole: int, y_whole: int, z_whole: int, w_whole: int, x_frac: T, y_frac: T, z_frac: T, w_frac: T) -> T {
         let [x, y, z, w] = gradient4::<T>(seed.get4(x_whole, y_whole, z_whole, w_whole));
         x_frac * x + y_frac * y + z_frac * z + w_frac * w
@@ -160,10 +135,10 @@ fn perlin4<T, F>(seed: &Seed, point: &::Point4<T>, scurve: F) -> T where
     let z1_frac = z0_frac - Float::one();
     let w1_frac = w0_frac - Float::one();
 
-    let x_curve = scurve(x0_frac);
-    let y_curve = scurve(y0_frac);
-    let z_curve = scurve(z0_frac);
-    let w_curve = scurve(w0_frac);
+    let x_curve = math::scurve5(x0_frac);
+    let y_curve = math::scurve5(y0_frac);
+    let z_curve = math::scurve5(z0_frac);
+    let w_curve = math::scurve5(w0_frac);
 
     let n0 = gradient(seed, x0_whole, y0_whole, z0_whole, w0_whole, x0_frac, y0_frac, z0_frac, w0_frac);
     let n1 = gradient(seed, x1_whole, y0_whole, z0_whole, w0_whole, x1_frac, y0_frac, z0_frac, w0_frac);
@@ -204,12 +179,4 @@ fn perlin4<T, F>(seed: &Seed, point: &::Point4<T>, scurve: F) -> T where
     let interpolated_z1 = math::lerp(z_curve, interpolated_y0, interpolated_y1);
 
     math::lerp(w_curve, interpolated_z0, interpolated_z1)
-}
-
-pub fn perlin4_fast<T: Float>(seed: &Seed, point: &::Point4<T>) -> T {
-    perlin4(seed, point, math::scurve3)
-}
-
-pub fn perlin4_best<T: Float>(seed: &Seed, point: &::Point4<T>) -> T {
-    perlin4(seed, point, math::scurve5)
 }

--- a/src/seed.rs
+++ b/src/seed.rs
@@ -75,10 +75,10 @@ impl Seed {
 #[cfg(test)]
 mod tests {
     use std::rand::random;
-    use perlin::perlin3_best;
+    use perlin::perlin3;
 
     #[test]
     fn test_random_seed() {
-        let _ = perlin3_best::<f32>(&random(), &[1.0, 2.0, 3.0]);
+        let _ = perlin3::<f32>(&random(), &[1.0, 2.0, 3.0]);
     }
 }


### PR DESCRIPTION
Now that we have proper benchmarks, it's become apparent that there is no measurable speed advantage to using scurve3 over scurve5 in the perlin noise, which means perlinX_fast wasn't actually any faster than perlinX_best. Thus, for the sake of simplifying the API, this removes the perlinX_fast functions.