### PR TITLE
Pass inputs through black box to avoid overoptimization

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -16,6 +16,7 @@
 //! An example of using simplectic noise
 
 #![feature(macro_rules)]
+#![feature(asm)]
 
 extern crate noise;
 extern crate test;
@@ -23,50 +24,57 @@ extern crate test;
 use noise::{perlin2, perlin3, perlin4, simplex2, simplex3, simplectic2, simplectic3, simplectic4, Seed};
 use test::Bencher;
 
+fn black_box<T>(dummy: T) -> T {
+    // we need to "use" the argument in some way LLVM can't
+    // introspect.
+    unsafe { asm!("" : : "r"(&dummy)) }
+    dummy
+}
+
 #[bench]
 fn bench_perlin2(bencher: &mut Bencher) {
     let seed = Seed::new(0);
-    bencher.iter(|| perlin2(&seed, &[42.0f32, 37.0]));
+    bencher.iter(|| perlin2(black_box(&seed), black_box(&[42.0f32, 37.0])));
 }
 
 #[bench]
 fn bench_perlin3(bencher: &mut Bencher) {
     let seed = Seed::new(0);
-    bencher.iter(|| perlin3(&seed, &[42.0f32, 37.0, 26.0]));
+    bencher.iter(|| perlin3(black_box(&seed), black_box(&[42.0f32, 37.0, 26.0])));
 }
 
 #[bench]
 fn bench_perlin4(bencher: &mut Bencher) {
     let seed = Seed::new(0);
-    bencher.iter(|| perlin4(&seed, &[42.0f32, 37.0, 26.0, 128.0]));
+    bencher.iter(|| perlin4(black_box(&seed), black_box(&[42.0f32, 37.0, 26.0, 128.0])));
 }
 
 #[bench]
 fn bench_simplex2(bencher: &mut Bencher) {
     let seed = Seed::new(0);
-    bencher.iter(|| simplex2(&seed, &[42.0f32, 37.0]));
+    bencher.iter(|| simplex2(black_box(&seed), black_box(&[42.0f32, 37.0])));
 }
 
 #[bench]
 fn bench_simplex3(bencher: &mut Bencher) {
     let seed = Seed::new(0);
-    bencher.iter(|| simplex3(&seed, &[42.0f32, 37.0, 26.0]));
+    bencher.iter(|| simplex3(black_box(&seed), black_box(&[42.0f32, 37.0, 26.0])));
 }
 
 #[bench]
 fn bench_simplectic2(bencher: &mut Bencher) {
     let seed = Seed::new(0);
-    bencher.iter(|| simplectic2(&seed, &[42.0f32, 37.0]));
+    bencher.iter(|| simplectic2(black_box(&seed), black_box(&[42.0f32, 37.0])));
 }
 
 #[bench]
 fn bench_simplectic3(bencher: &mut Bencher) {
     let seed = Seed::new(0);
-    bencher.iter(|| simplectic3(&seed, &[42.0f32, 37.0, 26.0]));
+    bencher.iter(|| simplectic3(black_box(&seed), black_box(&[42.0f32, 37.0, 26.0])));
 }
 
 #[bench]
 fn bench_simplectic4(bencher: &mut Bencher) {
     let seed = Seed::new(0);
-    bencher.iter(|| simplectic4(&seed, &[42.0f32, 37.0, 26.0, 128.0]));
+    bencher.iter(|| simplectic4(black_box(&seed), black_box(&[42.0f32, 37.0, 26.0, 128.0])));
 }

--- a/src/gradient.rs
+++ b/src/gradient.rs
@@ -34,6 +34,7 @@ pub fn get2<T: Float>(index: uint) -> ::Point2<T> {
     }
 }
 
+#[inline(always)]
 pub fn get3<T: Float>(index: uint) -> ::Point3<T> {
     let diag: T = math::cast(0.70710678118f32);
     let zero: T = math::cast(0.0f32);


### PR DESCRIPTION
Without this the compiler precomputes most/all of the functions and we aren't really benchmarking them.