### PR TITLE
OpenSimplex simplification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ name = "perlin"
 
 [[example]]
 
-name = "simplex"
+name = "open_simplex"
 
 [[example]]
 

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -21,7 +21,7 @@
 extern crate noise;
 extern crate test;
 
-use noise::{perlin2, perlin3, perlin4, simplex2, simplex3, simplectic2, simplectic3, simplectic4, Seed};
+use noise::{perlin2, perlin3, perlin4, open_simplex2, open_simplex3, simplectic2, simplectic3, simplectic4, Seed};
 use test::Bencher;
 
 fn black_box<T>(dummy: T) -> T {
@@ -50,15 +50,15 @@ fn bench_perlin4(bencher: &mut Bencher) {
 }
 
 #[bench]
-fn bench_simplex2(bencher: &mut Bencher) {
+fn bench_open_simplex2(bencher: &mut Bencher) {
     let seed = Seed::new(0);
-    bencher.iter(|| simplex2(black_box(&seed), black_box(&[42.0f32, 37.0])));
+    bencher.iter(|| open_simplex2(black_box(&seed), black_box(&[42.0f32, 37.0])));
 }
 
 #[bench]
-fn bench_simplex3(bencher: &mut Bencher) {
+fn bench_open_simplex3(bencher: &mut Bencher) {
     let seed = Seed::new(0);
-    bencher.iter(|| simplex3(black_box(&seed), black_box(&[42.0f32, 37.0, 26.0])));
+    bencher.iter(|| open_simplex3(black_box(&seed), black_box(&[42.0f32, 37.0, 26.0])));
 }
 
 #[bench]
@@ -116,24 +116,24 @@ fn bench_perlin4_64x64(bencher: &mut Bencher) {
 }
 
 #[bench]
-fn bench_simplex2_64x64(bencher: &mut Bencher) {
+fn bench_open_simplex2_64x64(bencher: &mut Bencher) {
     let seed = Seed::new(0);
     bencher.iter(|| {
         for y in range(0, 64u) {
             for x in range(0, 64u) {
-                black_box(simplex2(black_box(&seed), &[x as f32, y as f32]));
+                black_box(open_simplex2(black_box(&seed), &[x as f32, y as f32]));
             }
         }
     });
 }
 
 #[bench]
-fn bench_simplex3_64x64(bencher: &mut Bencher) {
+fn bench_open_simplex3_64x64(bencher: &mut Bencher) {
     let seed = Seed::new(0);
     bencher.iter(|| {
         for y in range(0, 64u) {
             for x in range(0, 64u) {
-                black_box(simplex3(black_box(&seed), &[x as f32, y as f32, x as f32]));
+                black_box(open_simplex3(black_box(&seed), &[x as f32, y as f32, x as f32]));
             }
         }
     });

--- a/examples/open_simplex.rs
+++ b/examples/open_simplex.rs
@@ -19,20 +19,20 @@
 
 extern crate noise;
 
-use noise::{simplex2, simplex3, Seed, Point2};
+use noise::{open_simplex2, open_simplex3, Seed, Point2};
 
 mod debug;
 
 fn main() {
-    debug::render_png("simplex2.png", &Seed::new(0), 256, 256, scaled_simplex2);
-    debug::render_png("simplex3.png", &Seed::new(0), 256, 256, scaled_simplex3);
+    debug::render_png("open_simplex2.png", &Seed::new(0), 256, 256, scaled_open_simplex2);
+    debug::render_png("open_simplex3.png", &Seed::new(0), 256, 256, scaled_open_simplex3);
     println!("\nGenerated simplex2.png and simplex3.png");
 }
 
-fn scaled_simplex2(seed: &Seed, point: &Point2<f32>) -> f32 {
-    simplex2(seed, &[point[0] / 32.0, point[1] / 32.00])
+fn scaled_open_simplex2(seed: &Seed, point: &Point2<f32>) -> f32 {
+    open_simplex2(seed, &[point[0] / 32.0, point[1] / 32.00])
 }
 
-fn scaled_simplex3(seed: &Seed, point: &Point2<f32>) -> f32 {
-    simplex3(seed, &[point[0] / 32.0, point[1] / 32.00, 0.0])
+fn scaled_open_simplex3(seed: &Seed, point: &Point2<f32>) -> f32 {
+    open_simplex3(seed, &[point[0] / 32.0, point[1] / 32.00, 0.0])
 }

--- a/examples/open_simplex.rs
+++ b/examples/open_simplex.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The noise-rs developers. For a full listing of the authors,
+// Copyright 2015 The noise-rs developers. For a full listing of the authors,
 // refer to the AUTHORS file at the top-level directory of this distribution.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,7 +26,7 @@ mod debug;
 fn main() {
     debug::render_png("open_simplex2.png", &Seed::new(0), 256, 256, scaled_open_simplex2);
     debug::render_png("open_simplex3.png", &Seed::new(0), 256, 256, scaled_open_simplex3);
-    println!("\nGenerated simplex2.png and simplex3.png");
+    println!("\nGenerated open_simplex2.png and open_simplex3.png");
 }
 
 fn scaled_open_simplex2(seed: &Seed, point: &Point2<f32>) -> f32 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 pub use seed::Seed;
 pub use math::{Point2, Point3, Point4};
 pub use perlin::{perlin2, perlin3, perlin4};
-pub use simplex::{simplex2, simplex3};
+pub use open_simplex::{open_simplex2, open_simplex3};
 pub use simplectic::{simplectic2, simplectic3, simplectic4};
 pub use brownian::{Brownian2, Brownian3, Brownian4};
 
@@ -30,5 +30,5 @@ mod seed;
 
 mod brownian;
 mod perlin;
-mod simplex;
+mod open_simplex;
 mod simplectic;

--- a/src/open_simplex.rs
+++ b/src/open_simplex.rs
@@ -29,7 +29,7 @@ const SQUISH_CONSTANT_3D: f64 = 1.0 / 3.0; //(Math.sqrt(3+1)-1)/3;
 const NORM_CONSTANT_2D: f32 = 1.0 / 14.0;
 const NORM_CONSTANT_3D: f32 = 1.0 / 14.0;
 
-pub fn simplex2<T: Float>(seed: &Seed, point: &::Point2<T>) -> T {
+pub fn open_simplex2<T: Float>(seed: &Seed, point: &::Point2<T>) -> T {
     fn gradient<T: Float>(seed: &Seed, xs_floor: T, ys_floor: T, dx: T, dy: T) -> T {
         let attn = math::cast::<_, T>(2.0_f64) - dx * dx - dy * dy;
         if attn > Float::zero() {
@@ -96,7 +96,7 @@ pub fn simplex2<T: Float>(seed: &Seed, point: &::Point2<T>) -> T {
     value * math::cast(NORM_CONSTANT_2D)
 }
 
-pub fn simplex3<T: Float>(seed: &Seed, point: &::Point3<T>) -> T {
+pub fn open_simplex3<T: Float>(seed: &Seed, point: &::Point3<T>) -> T {
     fn gradient<T: Float>(seed: &Seed, xs_floor: T, ys_floor: T, zs_floor: T, dx: T, dy: T, dz: T) -> T {
         let attn = math::cast::<_, T>(2.0_f64) - dx * dx - dy * dy - dz * dz;
         if attn > Float::zero() {


### PR DESCRIPTION
Rename simplex to open_simplex, and strip out the superfluous extra points, which greatly simplifies the code, and gives it about a 20% speed boost with no discernible difference to the output.