### PR TITLE
Squelch 1.0 alpha warnings

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,3 +7,4 @@ With help and contributions from:
 
 tiffany352          https://github.com/tiffany352
 James Miller <james@aatch.net>
+Michael Powell <herufeanor@gmail.com>, http://spiritofiron.com

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ keywords = ["math", "random"]
 authors = ["Brendan Zabarauskas <bjzaba@yahoo.com.au>",
            "tiffany352 <https://github.com/tiffany352>",
            "James Miller <james@aatch.net>",
-           "Travis Watkins <amaranth@ubuntu.com>"]
+           "Travis Watkins <amaranth@ubuntu.com>",
+           "Michael Powell <herufeanor@gmail.com"]
 
 [lib]
 

--- a/src/brownian.rs
+++ b/src/brownian.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The noise-rs developers. For a full listing of the authors,
+// Copyright 2015 The noise-rs developers. For a full listing of the authors,
 // refer to the AUTHORS file at the top-level directory of this distribution.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +12,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+#![allow(unstable)]
 
 use std::num::Float;
 

--- a/src/math.rs
+++ b/src/math.rs
@@ -15,6 +15,7 @@
 
 use std::num::{self, Float, NumCast};
 
+#[allow(unstable)]
 pub fn cast<T: NumCast, U: NumCast>(x: T) -> U {
     num::cast(x).unwrap()
 }

--- a/src/seed.rs
+++ b/src/seed.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The noise-rs developers. For a full listing of the authors,
+// Copyright 2015 The noise-rs developers. For a full listing of the authors,
 // refer to the AUTHORS file at the top-level directory of this distribution.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +12,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+#![allow(unstable)]
 
 use std::rand::{Rand, Rng, SeedableRng, XorShiftRng};
 use std::num::SignedInt;


### PR DESCRIPTION
Explicitly squelch the last few 1.0 alpha "unstable" warnings, which we can't really do anything about yet. Should be able to remove this by the time we reach 1.0 beta.