### PR TITLE
Improve Perlin's usage of Seed.

### DIFF
--- a/src/perlin.rs
+++ b/src/perlin.rs
@@ -44,10 +44,10 @@ pub fn perlin2<T: Float>(seed: &Seed, point: &math::Point2<T>) -> T {
     let x_curve = math::scurve5(x0_frac);
     let y_curve = math::scurve5(y0_frac);
 
-    let x0_cache = seed.get1(x0_whole);
-    let y0_cache = seed.get1(y0_whole);
-    let x1_cache = seed.get1(x1_whole);
-    let y1_cache = seed.get1(y1_whole);
+    let x0_cache = seed.getx(x0_whole);
+    let y0_cache = seed.gety(y0_whole);
+    let x1_cache = seed.getx(x1_whole);
+    let y1_cache = seed.gety(y1_whole);
 
     let f00 = gradient([x0_cache, y0_cache], [x0_frac, y0_frac]);
     let f10 = gradient([x1_cache, y0_cache], [x1_frac, y0_frac]);
@@ -90,12 +90,12 @@ pub fn perlin3<T: Float>(seed: &Seed, point: &math::Point3<T>) -> T {
     let y_curve = math::scurve5(y0_frac);
     let z_curve = math::scurve5(z0_frac);
 
-    let x0_cache = seed.get1(x0_whole);
-    let y0_cache = seed.get1(y0_whole);
-    let z0_cache = seed.get1(z0_whole);
-    let x1_cache = seed.get1(x1_whole);
-    let y1_cache = seed.get1(y1_whole);
-    let z1_cache = seed.get1(z1_whole);
+    let x0_cache = seed.getx(x0_whole);
+    let y0_cache = seed.gety(y0_whole);
+    let z0_cache = seed.getz(z0_whole);
+    let x1_cache = seed.getx(x1_whole);
+    let y1_cache = seed.gety(y1_whole);
+    let z1_cache = seed.getz(z1_whole);
 
     let f000 = gradient([x0_cache, y0_cache, z0_cache], [x0_frac, y0_frac, z0_frac]);
     let f100 = gradient([x1_cache, y0_cache, z0_cache], [x1_frac, y0_frac, z0_frac]);
@@ -148,14 +148,14 @@ pub fn perlin4<T: Float>(seed: &Seed, point: &math::Point4<T>) -> T {
     let z_curve = math::scurve5(z0_frac);
     let w_curve = math::scurve5(w0_frac);
 
-    let x0_cache = seed.get1(x0_whole);
-    let y0_cache = seed.get1(y0_whole);
-    let z0_cache = seed.get1(z0_whole);
-    let w0_cache = seed.get1(w0_whole);
-    let x1_cache = seed.get1(x1_whole);
-    let y1_cache = seed.get1(y1_whole);
-    let z1_cache = seed.get1(z1_whole);
-    let w1_cache = seed.get1(w1_whole);
+    let x0_cache = seed.getx(x0_whole);
+    let y0_cache = seed.gety(y0_whole);
+    let z0_cache = seed.getz(z0_whole);
+    let w0_cache = seed.getw(w0_whole);
+    let x1_cache = seed.getx(x1_whole);
+    let y1_cache = seed.gety(y1_whole);
+    let z1_cache = seed.getz(z1_whole);
+    let w1_cache = seed.getw(w1_whole);
 
     let f0000 = gradient([x0_cache, y0_cache, z0_cache, w0_cache], [x0_frac, y0_frac, z0_frac, w0_frac]);
     let f1000 = gradient([x1_cache, y0_cache, z0_cache, w0_cache], [x1_frac, y0_frac, z0_frac, w0_frac]);

--- a/src/seed.rs
+++ b/src/seed.rs
@@ -69,23 +69,38 @@ impl Seed {
     }
 
     #[inline(always)]
-    pub fn get1<T: SignedInt>(&self, x: T) -> usize {
+    pub fn getx<T: SignedInt>(&self, x: T) -> usize {
         self.x_values[math::cast::<T, usize>(x & math::cast(TABLE_SIZE - 1))] as usize
     }
 
     #[inline(always)]
+    pub fn gety<T: SignedInt>(&self, y: T) -> usize {
+        self.y_values[math::cast::<T, usize>(y & math::cast(TABLE_SIZE - 1))] as usize
+    }
+
+    #[inline(always)]
+    pub fn getz<T: SignedInt>(&self, z: T) -> usize {
+        self.z_values[math::cast::<T, usize>(z & math::cast(TABLE_SIZE - 1))] as usize
+    }
+
+    #[inline(always)]
+    pub fn getw<T: SignedInt>(&self, w: T) -> usize {
+        self.w_values[math::cast::<T, usize>(w & math::cast(TABLE_SIZE - 1))] as usize
+    }
+
+    #[inline(always)]
     pub fn get2<T: SignedInt>(&self, pos: math::Point2<T>) -> usize {
-        self.get1(pos[0]) ^ self.y_values[math::cast::<T, usize>(pos[1] & math::cast(TABLE_SIZE - 1))] as usize
+        self.getx(pos[0]) ^ self.gety(pos[1])
     }
 
     #[inline(always)]
     pub fn get3<T: SignedInt>(&self, pos: math::Point3<T>) -> usize {
-        self.get2([pos[0], pos[1]]) ^ self.z_values[math::cast::<T, usize>(pos[2] & math::cast(TABLE_SIZE - 1))] as usize
+        self.getx(pos[0]) ^ self.gety(pos[1]) ^ self.getz(pos[2])
     }
 
     #[inline(always)]
     pub fn get4<T: SignedInt>(&self, pos: math::Point4<T>) -> usize {
-        self.get3([pos[0], pos[1], pos[2]]) ^ self.w_values[math::cast::<T, usize>(pos[3] & math::cast(TABLE_SIZE - 1))] as usize
+        self.getx(pos[0]) ^ self.gety(pos[1]) ^ self.getz(pos[2]) ^ self.getw(pos[3])
     }
 }
 


### PR DESCRIPTION
Perlin noise was calling Seed.get1() for all of it's queries, which means it was always pulling from the x_values permutation table. This causes some artifacts, and defeats the purpose of having 4 permutation tables.

This change fixes that, and cleans up the Seed code a little in the process.