### PR TITLE
Add initial naive implementation of cell noise.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,14 @@ name = "open_simplex"
 
 name = "brownian"
 
+[[example]]
+
+name = "cell_range"
+
+[[example]]
+
+name = "cell_range_inv"
+
 [[bench]]
 
 name = "benches"

--- a/README.md
+++ b/README.md
@@ -153,11 +153,11 @@ fn cell4_manhattan_inv<T: Float>(seed: &Seed, point: &Point4<T>) -> T;
 
 These are the set of functions for determining range between two points, which are used to determine which seed point is actually closest to the test point.
 
-Calculate the euclidian range between two points. This is what one normally things of as distance.
+Calculate the square of the euclidian range between two points. This is what one normally thinks of as range. It's squared because that's cheaper to calculate, and we only actually care about which distance is greater in this context.
 ~~~rust
-fn range_euclidian2<T: Float>(p1: Point2<T>, p2: Point2<T>) -> T;
-fn range_euclidian3<T: Float>(p1: Point3<T>, p2: Point3<T>) -> T;
-fn range_euclidian4<T: Float>(p1: Point4<T>, p2: Point4<T>) -> T;
+fn range_sqr_euclidian2<T: Float>(p1: Point2<T>, p2: Point2<T>) -> T;
+fn range_sqr_euclidian3<T: Float>(p1: Point3<T>, p2: Point3<T>) -> T;
+fn range_sqr_euclidian4<T: Float>(p1: Point4<T>, p2: Point4<T>) -> T;
 ~~~
 
 Calculate the manhattan range between two points. This is the sum of the coordinates in the offset vector, equivalent to the distance one would walk on the Manhattan streets between two points.
@@ -171,23 +171,23 @@ fn range_manhattan4<T: Float>(p1: Point4<T>, p2: Point4<T>) -> T;
 
 These are the set of functions for returning the nearest point, nearest 2 points, or the cell of the nearest point. If you want to do something a little unusual with the cell noise, you can call these directly to operate on this intermediate data.
 
-These functions, when given a point, will return the nearest seed point.
+These functions, when given a point, will return the nearest seed point, and the range to that point.
 ~~~rust
-fn cell2_seed_point<T, F>(seed: &Seed, point: &Point2<T>, range: F) -> Point2<T>
+fn cell2_seed_point<T, F>(seed: &Seed, point: &Point2<T>, range: F) -> (Point2<T>, T)
     where T: Float, F: fn(Point2<T>, Point2<T>) -> T;
-fn cell3_seed_point<T, F>(seed: &Seed, point: &Point3<T>, range: F) -> Point3<T>
+fn cell3_seed_point<T, F>(seed: &Seed, point: &Point3<T>, range: F) -> (Point3<T>, T)
     where T: Float, F: fn(Point3<T>, Point3<T>) -> T;
-fn cell4_seed_point<T, F>(seed: &Seed, point: &Point4<T>, range: F) -> Point4<T>
+fn cell4_seed_point<T, F>(seed: &Seed, point: &Point4<T>, range: F) -> (Point4<T>, T)
     where T: Float, F: fn(Point4<T>, Point4<T>) -> T;
 ~~~
 
-These functions, when given a point, will return the nearest 2 seed points. The first point is the nearest one, and the second point the second nearest.
+These functions, when given a point, will return the nearest 2 seed points, and the range to those points. The first point is the nearest one, and the second point the second nearest.
 ~~~rust
-fn cell2_seed_2_points<T, F>(seed: &Seed, point: &Point2<T>, range: F) -> (Point2<T>, Point2<T>)
+fn cell2_seed_2_points<T, F>(seed: &Seed, point: &Point2<T>, range: F) -> (Point2<T>, T, Point2<T>, T)
     where T: Float, F: fn(Point2<T>, Point2<T>) -> T;
-fn cell3_seed_2_points<T, F>(seed: &Seed, point: &Point3<T>, range: F) -> (Point3<T>, Point3<T>)
+fn cell3_seed_2_points<T, F>(seed: &Seed, point: &Point3<T>, range: F) -> (Point3<T>, T, Point3<T>, T)
     where T: Float, F: fn(Point3<T>, Point3<T>) -> T;
-fn cell4_seed_2_points<T, F>(seed: &Seed, point: &Point4<T>, range: F) -> (Point4<T>, Point4<T>)
+fn cell4_seed_2_points<T, F>(seed: &Seed, point: &Point4<T>, range: F) -> (Point4<T>, T, Point4<T>, T)
     where T: Float, F: fn(Point4<T>, Point4<T>) -> T;
 ~~~
 

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -22,6 +22,7 @@ extern crate noise;
 extern crate test;
 
 use noise::{perlin2, perlin3, perlin4, open_simplex2, open_simplex3, Seed};
+use noise::{cell2_range, cell3_range, cell4_range, cell2_range_inv, cell3_range_inv, cell4_range_inv};
 use test::Bencher;
 
 fn black_box<T>(dummy: T) -> T {
@@ -59,6 +60,42 @@ fn bench_open_simplex2(bencher: &mut Bencher) {
 fn bench_open_simplex3(bencher: &mut Bencher) {
     let seed = Seed::new(0);
     bencher.iter(|| open_simplex3(black_box(&seed), black_box(&[42.0f32, 37.0, 26.0])));
+}
+
+#[bench]
+fn bench_cell2_range(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| cell2_range(black_box(&seed), black_box(&[42.0f32, 37.0])));
+}
+
+#[bench]
+fn bench_cell3_range(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| cell3_range(black_box(&seed), black_box(&[42.0f32, 37.0, 26.0])));
+}
+
+#[bench]
+fn bench_cell4_range(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| cell4_range(black_box(&seed), black_box(&[42.0f32, 37.0, 26.0, 128.0])));
+}
+
+#[bench]
+fn bench_cell2_range_inv(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| cell2_range_inv(black_box(&seed), black_box(&[42.0f32, 37.0])));
+}
+
+#[bench]
+fn bench_cell3_range_inv(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| cell3_range_inv(black_box(&seed), black_box(&[42.0f32, 37.0, 26.0])));
+}
+
+#[bench]
+fn bench_cell4_range_inv(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| cell4_range_inv(black_box(&seed), black_box(&[42.0f32, 37.0, 26.0, 128.0])));
 }
 
 #[bench]
@@ -116,6 +153,78 @@ fn bench_open_simplex3_64x64(bencher: &mut Bencher) {
         for y in 0..64 {
             for x in 0..64 {
                 black_box(open_simplex3(black_box(&seed), &[x as f32, y as f32, x as f32]));
+            }
+        }
+    });
+}
+
+#[bench]
+fn bench_cell2_range_64x64(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| {
+        for y in 0..64 {
+            for x in 0..64 {
+                black_box(cell2_range(black_box(&seed), &[x as f32, y as f32]));
+            }
+        }
+    });
+}
+
+#[bench]
+fn bench_cell3_range_64x64(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| {
+        for y in 0..64 {
+            for x in 0..64 {
+                black_box(cell3_range(black_box(&seed), &[x as f32, y as f32, x as f32]));
+            }
+        }
+    });
+}
+
+#[bench]
+fn bench_cell4_range_64x64(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| {
+        for y in 0..64 {
+            for x in 0..64 {
+                black_box(cell4_range(black_box(&seed), &[x as f32, y as f32, x as f32, y as f32]));
+            }
+        }
+    });
+}
+
+#[bench]
+fn bench_cell2_range_inv_64x64(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| {
+        for y in 0..64 {
+            for x in 0..64 {
+                black_box(cell2_range_inv(black_box(&seed), &[x as f32, y as f32]));
+            }
+        }
+    });
+}
+
+#[bench]
+fn bench_cell3_range_inv_64x64(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| {
+        for y in 0..64 {
+            for x in 0..64 {
+                black_box(cell3_range_inv(black_box(&seed), &[x as f32, y as f32, x as f32]));
+            }
+        }
+    });
+}
+
+#[bench]
+fn bench_cell4_range_inv_64x64(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| {
+        for y in 0..64 {
+            for x in 0..64 {
+                black_box(cell4_range_inv(black_box(&seed), &[x as f32, y as f32, x as f32, y as f32]));
             }
         }
     });

--- a/examples/cell_range.rs
+++ b/examples/cell_range.rs
@@ -1,0 +1,41 @@
+// Copyright 2013 The noise-rs developers. For a full listing of the authors,
+// refer to the AUTHORS file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! An example of using cell range noise
+
+extern crate noise;
+
+use noise::{cell2_range, cell3_range, cell4_range, Seed, Point2};
+
+mod debug;
+
+fn main() {
+    debug::render_png("cell2_range.png", &Seed::new(0), 256, 256, scaled_cell2_range);
+    debug::render_png("cell3_range.png", &Seed::new(0), 256, 256, scaled_cell3_range);
+    debug::render_png("cell4_range.png", &Seed::new(0), 256, 256, scaled_cell4_range);
+    println!("\nGenerated cell2_range.png, cell3_range.png and cell4_range.png");
+}
+
+fn scaled_cell2_range(seed: &Seed, point: &Point2<f32>) -> f32 {
+    cell2_range(seed, &[point[0] / 32.0f32, point[1] / 32.00])
+}
+
+fn scaled_cell3_range(seed: &Seed, point: &Point2<f32>) -> f32 {
+    cell3_range(seed, &[point[0] / 32.0f32, point[1] / 32.00, 0.0])
+}
+
+fn scaled_cell4_range(seed: &Seed, point: &Point2<f32>) -> f32 {
+    cell4_range(seed, &[point[0] / 32.0f32, point[1] / 32.00, 0.0, 0.0])
+}

--- a/examples/cell_range_inv.rs
+++ b/examples/cell_range_inv.rs
@@ -1,0 +1,41 @@
+// Copyright 2013 The noise-rs developers. For a full listing of the authors,
+// refer to the AUTHORS file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! An example of using cell range noise
+
+extern crate noise;
+
+use noise::{cell2_range_inv, cell3_range_inv, cell4_range_inv, Seed, Point2};
+
+mod debug;
+
+fn main() {
+    debug::render_png("cell2_range_inv.png", &Seed::new(0), 256, 256, scaled_cell2_range_inv);
+    debug::render_png("cell3_range_inv.png", &Seed::new(0), 256, 256, scaled_cell3_range_inv);
+    debug::render_png("cell4_range_inv.png", &Seed::new(0), 256, 256, scaled_cell4_range_inv);
+    println!("\nGenerated cell2_range_inv.png, cell3_range_inv.png and cell4_range_inv.png");
+}
+
+fn scaled_cell2_range_inv(seed: &Seed, point: &Point2<f32>) -> f32 {
+    cell2_range_inv(seed, &[point[0] / 32.0f32, point[1] / 32.00])
+}
+
+fn scaled_cell3_range_inv(seed: &Seed, point: &Point2<f32>) -> f32 {
+    cell3_range_inv(seed, &[point[0] / 32.0f32, point[1] / 32.00, 0.0])
+}
+
+fn scaled_cell4_range_inv(seed: &Seed, point: &Point2<f32>) -> f32 {
+    cell4_range_inv(seed, &[point[0] / 32.0f32, point[1] / 32.00, 0.0, 0.0])
+}

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -1,0 +1,279 @@
+// Copyright 2015 The noise-rs developers. For a full listing of the authors,
+// refer to the AUTHORS file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use {math, Seed};
+use std::num::Float;
+
+#[inline(always)]
+fn get_cell2<T: Float>(point: math::Point2<T>) -> math::Point2<T> {
+    [point[0].floor(), point[1].floor()]
+}
+
+#[inline(always)]
+fn get_cell3<T: Float>(point: math::Point3<T>) -> math::Point3<T> {
+    [point[0].floor(), point[1].floor(), point[2].floor()]
+}
+
+#[inline(always)]
+fn get_cell4<T: Float>(point: math::Point4<T>) -> math::Point4<T> {
+    [point[0].floor(), point[1].floor(), point[2].floor(), point[3].floor()]
+}
+
+#[inline(always)]
+fn get_cell_point2<T: Float>(seed: &Seed, cell: math::Point2<T>) -> math::Point2<T> {
+    let val = seed.get2(math::cast2::<_,i64>(cell));
+    math::add2(cell, math::mul2(math::cast2([val & 0x0F, val & 0xF0 >> 4]), math::cast(1.0 / 15.0)))
+}
+
+#[inline(always)]
+fn get_cell_point3<T: Float>(seed: &Seed, cell: math::Point3<T>) -> math::Point3<T> {
+    let cell_int = math::cast3::<_,i64>(cell);
+    let val1 = seed.get3(cell_int);
+    let val2 = seed.get3([cell_int[0], cell_int[1], cell_int[2] + 128]);
+    math::add3(cell, math::mul3(math::cast3([val1 & 0x0F, val1 & 0xF0 >> 4, val2 & 0x0F]), math::cast(1.0 / 15.0)))
+}
+
+#[inline(always)]
+fn get_cell_point4<T: Float>(seed: &Seed, cell: math::Point4<T>) -> math::Point4<T> {
+    let cell_int = math::cast4::<_,i64>(cell);
+    let val1 = seed.get4(cell_int);
+    let val2 = seed.get4([cell_int[0], cell_int[1], cell_int[2], cell_int[3] + 128]);
+    math::add4(cell, math::mul4(math::cast4([val1 & 0x0F, val1 & 0xF0 >> 4, val2 & 0x0F, val2 & 0xF0 >> 4]), math::cast(1.0 / 15.0)))
+}
+
+#[inline(always)]
+pub fn range_sqr_euclidian2<T: Float>(p1: math::Point2<T>, p2: math::Point2<T>) -> T {
+    let offset = math::sub2(p1, p2);
+    math::dot2(offset, offset)
+}
+
+#[inline(always)]
+pub fn range_sqr_euclidian3<T: Float>(p1: math::Point3<T>, p2: math::Point3<T>) -> T {
+    let offset = math::sub3(p1, p2);
+    math::dot3(offset, offset)
+}
+
+#[inline(always)]
+pub fn range_sqr_euclidian4<T: Float>(p1: math::Point4<T>, p2: math::Point4<T>) -> T {
+    let offset = math::sub4(p1, p2);
+    math::dot4(offset, offset)
+}
+
+#[inline(always)]
+pub fn cell2_seed_point<T, F>(seed: &Seed, point: &math::Point2<T>, range_func: F) -> (math::Point2<T>, T)
+    where T: Float, F: Fn(math::Point2<T>, math::Point2<T>) -> T
+{
+    let zero: T = math::cast(0);
+
+    let cell = get_cell2(*point);
+    let mut range: T = Float::max_value();
+    let mut seed_point: math::Point2<T> = [zero, zero];
+
+    for x_offset in -1..2 {
+        for y_offset in -1..2 {
+            let cur_seed_point = get_cell_point2(seed, math::add2(cell, math::cast2([x_offset, y_offset])));
+            let cur_range = range_func(*point, cur_seed_point);
+            if cur_range < range {
+                range = cur_range;
+                seed_point = cur_seed_point;
+            }
+        }
+    }
+
+    (seed_point, range)
+}
+
+#[inline(always)]
+pub fn cell3_seed_point<T, F>(seed: &Seed, point: &math::Point3<T>, range_func: F) -> (math::Point3<T>, T)
+    where T: Float, F: Fn(math::Point3<T>, math::Point3<T>) -> T
+{
+    let zero: T = math::cast(0);
+
+    let cell = get_cell3(*point);
+    let mut range: T = Float::max_value();
+    let mut seed_point: math::Point3<T> = [zero, zero, zero];
+
+    for x_offset in -1..2 {
+        for y_offset in -1..2 {
+            for z_offset in -1..2 {
+                let cur_seed_point = get_cell_point3(seed, math::add3(cell, math::cast3([x_offset, y_offset, z_offset])));
+                let cur_range = range_func(*point, cur_seed_point);
+                if cur_range < range {
+                    range = cur_range;
+                    seed_point = cur_seed_point;
+                }
+            }
+        }
+    }
+
+    (seed_point, range)
+}
+
+#[inline(always)]
+pub fn cell4_seed_point<T, F>(seed: &Seed, point: &math::Point4<T>, range_func: F) -> (math::Point4<T>, T)
+    where T: Float, F: Fn(math::Point4<T>, math::Point4<T>) -> T
+{
+    let zero: T = math::cast(0);
+
+    let cell = get_cell4(*point);
+    let mut range: T = Float::max_value();
+    let mut seed_point: math::Point4<T> = [zero, zero, zero, zero];
+
+    for x_offset in -1..2 {
+        for y_offset in -1..2 {
+            for z_offset in -1..2 {
+                for w_offset in -1..2 {
+                    let cur_seed_point = get_cell_point4(seed, math::add4(cell, math::cast4([x_offset, y_offset, z_offset, w_offset])));
+                    let cur_range = range_func(*point, cur_seed_point);
+                    if cur_range < range {
+                        range = cur_range;
+                        seed_point = cur_seed_point;
+                    }
+                }
+            }
+        }
+    }
+
+    (seed_point, range)
+}
+
+#[inline(always)]
+pub fn cell2_seed_2_points<T, F>(seed: &Seed, point: &math::Point2<T>, range_func: F) -> (math::Point2<T>, T, math::Point2<T>, T)
+    where T: Float, F: Fn(math::Point2<T>, math::Point2<T>) -> T
+{
+    let zero: T = math::cast(0);
+
+    let cell = get_cell2(*point);
+    let mut range1: T = Float::max_value();
+    let mut range2: T = Float::max_value();
+    let mut seed_point1: math::Point2<T> = [zero, zero];
+    let mut seed_point2: math::Point2<T> = [zero, zero];
+
+    for x_offset in -1..2 {
+        for y_offset in -1..2 {
+            let cur_seed_point = get_cell_point2(seed, math::add2(cell, math::cast2([x_offset, y_offset])));
+            let cur_range = range_func(*point, cur_seed_point);
+            if cur_range < range1 {
+                range2 = range1;
+                seed_point2 = seed_point1;
+                range1 = cur_range;
+                seed_point1 = cur_seed_point;
+            } else if cur_range < range2 {
+                range2 = cur_range;
+                seed_point2 = cur_seed_point;
+            }
+        }
+    }
+
+    (seed_point1, range1, seed_point2, range2)
+}
+
+#[inline(always)]
+pub fn cell3_seed_2_points<T, F>(seed: &Seed, point: &math::Point3<T>, range_func: F) -> (math::Point3<T>, T, math::Point3<T>, T)
+    where T: Float, F: Fn(math::Point3<T>, math::Point3<T>) -> T
+{
+    let zero: T = math::cast(0);
+
+    let cell = get_cell3(*point);
+    let mut range1: T = Float::max_value();
+    let mut range2: T = Float::max_value();
+    let mut seed_point1: math::Point3<T> = [zero, zero, zero];
+    let mut seed_point2: math::Point3<T> = [zero, zero, zero];
+
+    for x_offset in -1..2 {
+        for y_offset in -1..2 {
+            for z_offset in -1..2 {
+                let cur_seed_point = get_cell_point3(seed, math::add3(cell, math::cast3([x_offset, y_offset, z_offset])));
+                let cur_range = range_func(*point, cur_seed_point);
+                if cur_range < range1 {
+                    range2 = range1;
+                    seed_point2 = seed_point1;
+                    range1 = cur_range;
+                    seed_point1 = cur_seed_point;
+                } else if cur_range < range2 {
+                    range2 = cur_range;
+                    seed_point2 = cur_seed_point;
+                }
+            }
+        }
+    }
+
+    (seed_point1, range1, seed_point2, range2)
+}
+
+#[inline(always)]
+pub fn cell4_seed_2_points<T, F>(seed: &Seed, point: &math::Point4<T>, range_func: F) -> (math::Point4<T>, T, math::Point4<T>, T)
+    where T: Float, F: Fn(math::Point4<T>, math::Point4<T>) -> T
+{
+    let zero: T = math::cast(0);
+
+    let cell = get_cell4(*point);
+    let mut range1: T = Float::max_value();
+    let mut range2: T = Float::max_value();
+    let mut seed_point1: math::Point4<T> = [zero, zero, zero, zero];
+    let mut seed_point2: math::Point4<T> = [zero, zero, zero, zero];
+
+    for x_offset in -1..2 {
+        for y_offset in -1..2 {
+            for z_offset in -1..2 {
+                for w_offset in -1..2 {
+                    let cur_seed_point = get_cell_point4(seed, math::add4(cell, math::cast4([x_offset, y_offset, z_offset, w_offset])));
+                    let cur_range = range_func(*point, cur_seed_point);
+                    if cur_range < range1 {
+                        range2 = range1;
+                        seed_point2 = seed_point1;
+                        range1 = cur_range;
+                        seed_point1 = cur_seed_point;
+                    } else if cur_range < range2 {
+                        range2 = cur_range;
+                        seed_point2 = cur_seed_point;
+                    }
+                }
+            }
+        }
+    }
+
+    (seed_point1, range1, seed_point2, range2)
+}
+
+pub fn cell2_range<T: Float>(seed: &Seed, point: &math::Point2<T>) -> T {
+    let (_, range) = cell2_seed_point(seed, point, range_sqr_euclidian2);
+    range
+}
+
+pub fn cell3_range<T: Float>(seed: &Seed, point: &math::Point3<T>) -> T {
+    let (_, range) = cell3_seed_point(seed, point, range_sqr_euclidian3);
+    range
+}
+
+pub fn cell4_range<T: Float>(seed: &Seed, point: &math::Point4<T>) -> T {
+    let (_, range) = cell4_seed_point(seed, point, range_sqr_euclidian4);
+    range
+}
+
+pub fn cell2_range_inv<T: Float>(seed: &Seed, point: &math::Point2<T>) -> T {
+    let (_, range1, _, range2) = cell2_seed_2_points(seed, point, range_sqr_euclidian2);
+    range2 - range1
+}
+
+pub fn cell3_range_inv<T: Float>(seed: &Seed, point: &math::Point3<T>) -> T {
+    let (_, range1, _, range2) = cell3_seed_2_points(seed, point, range_sqr_euclidian3);
+    range2 - range1
+}
+
+pub fn cell4_range_inv<T: Float>(seed: &Seed, point: &math::Point4<T>) -> T {
+    let (_, range1, _, range2) = cell4_seed_2_points(seed, point, range_sqr_euclidian4);
+    range2 - range1
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,11 @@ pub use perlin::{perlin2, perlin3, perlin4};
 pub use open_simplex::{open_simplex2, open_simplex3};
 pub use brownian::{Brownian2, Brownian3, Brownian4};
 
+pub use cell::{range_sqr_euclidian2, range_sqr_euclidian3, range_sqr_euclidian4};
+pub use cell::{cell2_seed_point, cell3_seed_point, cell4_seed_point};
+pub use cell::{cell2_range, cell3_range, cell4_range};
+pub use cell::{cell2_range_inv, cell3_range_inv, cell4_range_inv};
+
 mod gradient;
 mod math;
 mod seed;
@@ -30,3 +35,4 @@ mod seed;
 mod brownian;
 mod perlin;
 mod open_simplex;
+mod cell;

--- a/src/math.rs
+++ b/src/math.rs
@@ -60,6 +60,66 @@ pub type Vector3<T> = [T; 3];
 /// A 4-dimensional vector
 pub type Vector4<T> = [T; 4];
 
+/// Cast a 2-dimensional point
+pub fn cast2<T: NumCast + Copy, U: NumCast + Copy>(x: Point2<T>) -> Point2<U> {
+    [cast(x[0]), cast(x[1])]
+}
+
+/// Cast a 3-dimensional point
+pub fn cast3<T: NumCast + Copy, U: NumCast + Copy>(x: Point3<T>) -> Point3<U> {
+    [cast(x[0]), cast(x[1]), cast(x[2])]
+}
+
+/// Cast a 4-dimensional point
+pub fn cast4<T: NumCast + Copy, U: NumCast + Copy>(x: Point4<T>) -> Point4<U> {
+    [cast(x[0]), cast(x[1]), cast(x[2]), cast(x[3])]
+}
+
+/// Get the vector between two 2-dimensional points
+pub fn sub2<T: Float>(a: Point2<T>, b: Point2<T>) -> Vector2<T> {
+    [a[0] - b[0], a[1] - b[1]]
+}
+
+/// Get the vector between two 3-dimensional points
+pub fn sub3<T: Float>(a: Point3<T>, b: Point3<T>) -> Vector3<T> {
+    [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
+}
+
+/// Get the vector between two 4-dimensional points
+pub fn sub4<T: Float>(a: Point4<T>, b: Point4<T>) -> Vector4<T> {
+    [a[0] - b[0], a[1] - b[1], a[2] - b[2], a[3] - b[3]]
+}
+
+/// Translate a 2-dimensional point by a vector
+pub fn add2<T: Float>(a: Point2<T>, b: Vector2<T>) -> Point2<T> {
+    [a[0] + b[0], a[1] + b[1]]
+}
+
+/// Translate a 3-dimensional point by a vector
+pub fn add3<T: Float>(a: Point3<T>, b: Vector3<T>) -> Point3<T> {
+    [a[0] + b[0], a[1] + b[1], a[2] + b[2]]
+}
+
+/// Translate a 4-dimensional point by a vector
+pub fn add4<T: Float>(a: Point4<T>, b: Vector4<T>) -> Point4<T> {
+    [a[0] + b[0], a[1] + b[1], a[2] + b[2], a[3] + b[3]]
+}
+
+/// Scale a 2-dimensional point by a scalar
+pub fn mul2<T: Float>(a: Point2<T>, b: T) -> Point2<T> {
+    [a[0] * b, a[1] * b]
+}
+
+/// Scale a 3-dimensional point by a scalar
+pub fn mul3<T: Float>(a: Point3<T>, b: T) -> Point3<T> {
+    [a[0] * b, a[1] * b, a[2] * b]
+}
+
+/// Scale a 4-dimensional point by a scalar
+pub fn mul4<T: Float>(a: Point4<T>, b: T) -> Point4<T> {
+    [a[0] * b, a[1] * b, a[2] * b, a[3] * b]
+}
+
 /// The dot product of two 2-dimensional vectors
 pub fn dot2<T: Float>(a: Vector2<T>, b: Vector2<T>) -> T {
     a[0] * b[0] + a[1] * b[1]


### PR DESCRIPTION
This version of cell noise is VERY slow, but there is substantial room for optimization. This provides a starting point. It also doesn't have the manhattan functions yet.

While adding this, I also added a number of functions to math.rs for adding, subtracting, scaling and casting points and vectors. They don't use operator overloading, because PointN and VectorN are currently just type aliases to arrays, and implementing standard library traits on a built-in type would be an orphan implementation, which isn't allowed.