### PR TITLE
Add the rest of the cell noise types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,14 @@ name = "cell_range"
 
 name = "cell_range_inv"
 
+[[example]]
+
+name = "cell_manhattan"
+
+[[example]]
+
+name = "cell_manhattan_inv"
+
 [[bench]]
 
 name = "benches"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,10 @@ name = "cell_range_inv"
 
 [[example]]
 
+name = "cell_value"
+
+[[example]]
+
 name = "cell_manhattan"
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,10 @@ name = "cell_manhattan"
 
 name = "cell_manhattan_inv"
 
+[[example]]
+
+name = "cell_manhattan_value"
+
 [[bench]]
 
 name = "benches"

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ pub type Point3<T> = [T; 3];
 pub type Point4<T> = [T; 4];
 ~~~
 
+Gradient Noise
+--------------
+Gradient noise produces a smooth, continuous value over space. It's achieved by dividing space into regions, and placing a random gradient at each vertex, then blending between those gradients.
+
+**Perlin Noise**
+
 Perlin noise is a very fast and reasonable quality gradient noise.
 ~~~rust
 fn perlin2<T: Float>(seed: &Seed, point: &Point2<T>) -> T;
@@ -31,13 +37,17 @@ fn perlin3<T: Float>(seed: &Seed, point: &Point3<T>) -> T;
 fn perlin4<T: Float>(seed: &Seed, point: &Point4<T>) -> T;
 ~~~
 
+**OpenSimplex Noise**
+
 OpenSimplex noise is a slower but higher quality form of gradient noise.
 ~~~rust
 fn open_simplex2<T: Float>(seed: &Seed, point: &Point2<T>) -> T;
 fn open_simplex3<T: Float>(seed: &Seed, point: &Point3<T>) -> T;
 ~~~
 
-Fractional Brownian Motion is a way of combining multiple versions of a noise function to create a richer and more varied output.
+**Fractional Brownian Motion**
+
+Fractional Brownian Motion is a way of combining multiple octaves of a noise function to create a richer and more varied output. It can theoretically be used with any noise function, but it tends to only produce good results with gradient noise functions.
 
 Example:
 ~~~rust
@@ -93,13 +103,8 @@ impl<T, F> Brownian3<T, F> {
 impl<T, F> Fn(&Seed, &Point4<T>) -> T for Brownian4<T, F> { ... }
 ~~~
 
-Coming soon
------------
-Everything below this line is planned, but not yet implemented.
-
-~~~rust
-fn open_simplex4<T: Float>(seed: &Seed, point: &Point4<T>) -> T;
-~~~
+Cell Noise
+----------
 
 Cell noise, also called worley noise or voronoi noise, is based on dividing space into cells based on proximity to a random set of seed points. In this API, this is accomplished in three categories.
 
@@ -199,4 +204,12 @@ fn cell3_seed_cell<T, F>(seed: &Seed, point: &Point3<T>, range: F) -> Point3<i64
     where T: Float, F: fn(Point3<T>, Point3<T>) -> T;
 fn cell4_seed_cell<T, F>(seed: &Seed, point: &Point4<T>, range: F) -> Point4<i64>
     where T: Float, F: fn(Point4<T>, Point4<T>) -> T;
+~~~
+
+Coming soon
+-----------
+Everything below this line is planned, but not yet implemented.
+
+~~~rust
+fn open_simplex4<T: Float>(seed: &Seed, point: &Point4<T>) -> T;
 ~~~

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -29,6 +29,7 @@ use noise::{cell2_range_inv, cell3_range_inv, cell4_range_inv};
 use noise::{cell2_value, cell3_value, cell4_value};
 use noise::{cell2_manhattan, cell3_manhattan, cell4_manhattan};
 use noise::{cell2_manhattan_inv, cell3_manhattan_inv, cell4_manhattan_inv};
+use noise::{cell2_manhattan_value, cell3_manhattan_value, cell4_manhattan_value};
 use test::Bencher;
 
 fn black_box<T>(dummy: T) -> T {
@@ -156,6 +157,24 @@ fn bench_cell3_manhattan_inv(bencher: &mut Bencher) {
 fn bench_cell4_manhattan_inv(bencher: &mut Bencher) {
     let seed = Seed::new(0);
     bencher.iter(|| cell4_manhattan_inv(black_box(&seed), black_box(&[42.0f32, 37.0, 26.0, 128.0])));
+}
+
+#[bench]
+fn bench_cell2_manhattan_value(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| cell2_manhattan_value(black_box(&seed), black_box(&[42.0f32, 37.0])));
+}
+
+#[bench]
+fn bench_cell3_manhattan_value(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| cell3_manhattan_value(black_box(&seed), black_box(&[42.0f32, 37.0, 26.0])));
+}
+
+#[bench]
+fn bench_cell4_manhattan_value(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| cell4_manhattan_value(black_box(&seed), black_box(&[42.0f32, 37.0, 26.0, 128.0])));
 }
 
 #[bench]
@@ -393,6 +412,42 @@ fn bench_cell4_manhattan_inv_64x64(bencher: &mut Bencher) {
         for y in 0..64 {
             for x in 0..64 {
                 black_box(cell4_manhattan_inv(black_box(&seed), &[x as f32, y as f32, x as f32, y as f32]));
+            }
+        }
+    });
+}
+
+#[bench]
+fn bench_cell2_manhattan_value_64x64(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| {
+        for y in 0..64 {
+            for x in 0..64 {
+                black_box(cell2_manhattan_value(black_box(&seed), &[x as f32, y as f32]));
+            }
+        }
+    });
+}
+
+#[bench]
+fn bench_cell3_manhattan_value_64x64(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| {
+        for y in 0..64 {
+            for x in 0..64 {
+                black_box(cell3_manhattan_value(black_box(&seed), &[x as f32, y as f32, x as f32]));
+            }
+        }
+    });
+}
+
+#[bench]
+fn bench_cell4_manhattan_value_64x64(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| {
+        for y in 0..64 {
+            for x in 0..64 {
+                black_box(cell4_manhattan_value(black_box(&seed), &[x as f32, y as f32, x as f32, y as f32]));
             }
         }
     });

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -21,9 +21,14 @@
 extern crate noise;
 extern crate test;
 
-use noise::{perlin2, perlin3, perlin4, open_simplex2, open_simplex3, Seed};
-use noise::{cell2_range, cell3_range, cell4_range, cell2_range_inv, cell3_range_inv, cell4_range_inv};
-use noise::{cell2_manhattan, cell3_manhattan, cell4_manhattan, cell2_manhattan_inv, cell3_manhattan_inv, cell4_manhattan_inv};
+use noise::Seed;
+use noise::{perlin2, perlin3, perlin4};
+use noise::{open_simplex2, open_simplex3};
+use noise::{cell2_range, cell3_range, cell4_range};
+use noise::{cell2_range_inv, cell3_range_inv, cell4_range_inv};
+use noise::{cell2_value, cell3_value, cell4_value};
+use noise::{cell2_manhattan, cell3_manhattan, cell4_manhattan};
+use noise::{cell2_manhattan_inv, cell3_manhattan_inv, cell4_manhattan_inv};
 use test::Bencher;
 
 fn black_box<T>(dummy: T) -> T {
@@ -97,6 +102,24 @@ fn bench_cell3_range_inv(bencher: &mut Bencher) {
 fn bench_cell4_range_inv(bencher: &mut Bencher) {
     let seed = Seed::new(0);
     bencher.iter(|| cell4_range_inv(black_box(&seed), black_box(&[42.0f32, 37.0, 26.0, 128.0])));
+}
+
+#[bench]
+fn bench_cell2_value(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| cell2_value(black_box(&seed), black_box(&[42.0f32, 37.0])));
+}
+
+#[bench]
+fn bench_cell3_value(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| cell3_value(black_box(&seed), black_box(&[42.0f32, 37.0, 26.0])));
+}
+
+#[bench]
+fn bench_cell4_value(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| cell4_value(black_box(&seed), black_box(&[42.0f32, 37.0, 26.0, 128.0])));
 }
 
 #[bench]
@@ -262,6 +285,42 @@ fn bench_cell4_range_inv_64x64(bencher: &mut Bencher) {
         for y in 0..64 {
             for x in 0..64 {
                 black_box(cell4_range_inv(black_box(&seed), &[x as f32, y as f32, x as f32, y as f32]));
+            }
+        }
+    });
+}
+
+#[bench]
+fn bench_cell2_value_64x64(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| {
+        for y in 0..64 {
+            for x in 0..64 {
+                black_box(cell2_value(black_box(&seed), &[x as f32, y as f32]));
+            }
+        }
+    });
+}
+
+#[bench]
+fn bench_cell3_value_64x64(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| {
+        for y in 0..64 {
+            for x in 0..64 {
+                black_box(cell3_value(black_box(&seed), &[x as f32, y as f32, x as f32]));
+            }
+        }
+    });
+}
+
+#[bench]
+fn bench_cell4_value_64x64(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| {
+        for y in 0..64 {
+            for x in 0..64 {
+                black_box(cell4_value(black_box(&seed), &[x as f32, y as f32, x as f32, y as f32]));
             }
         }
     });

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -23,6 +23,7 @@ extern crate test;
 
 use noise::{perlin2, perlin3, perlin4, open_simplex2, open_simplex3, Seed};
 use noise::{cell2_range, cell3_range, cell4_range, cell2_range_inv, cell3_range_inv, cell4_range_inv};
+use noise::{cell2_manhattan, cell3_manhattan, cell4_manhattan, cell2_manhattan_inv, cell3_manhattan_inv, cell4_manhattan_inv};
 use test::Bencher;
 
 fn black_box<T>(dummy: T) -> T {
@@ -96,6 +97,42 @@ fn bench_cell3_range_inv(bencher: &mut Bencher) {
 fn bench_cell4_range_inv(bencher: &mut Bencher) {
     let seed = Seed::new(0);
     bencher.iter(|| cell4_range_inv(black_box(&seed), black_box(&[42.0f32, 37.0, 26.0, 128.0])));
+}
+
+#[bench]
+fn bench_cell2_manhattan(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| cell2_manhattan(black_box(&seed), black_box(&[42.0f32, 37.0])));
+}
+
+#[bench]
+fn bench_cell3_manhattan(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| cell3_manhattan(black_box(&seed), black_box(&[42.0f32, 37.0, 26.0])));
+}
+
+#[bench]
+fn bench_cell4_manhattan(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| cell4_manhattan(black_box(&seed), black_box(&[42.0f32, 37.0, 26.0, 128.0])));
+}
+
+#[bench]
+fn bench_cell2_manhattan_inv(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| cell2_manhattan_inv(black_box(&seed), black_box(&[42.0f32, 37.0])));
+}
+
+#[bench]
+fn bench_cell3_manhattan_inv(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| cell3_manhattan_inv(black_box(&seed), black_box(&[42.0f32, 37.0, 26.0])));
+}
+
+#[bench]
+fn bench_cell4_manhattan_inv(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| cell4_manhattan_inv(black_box(&seed), black_box(&[42.0f32, 37.0, 26.0, 128.0])));
 }
 
 #[bench]
@@ -225,6 +262,78 @@ fn bench_cell4_range_inv_64x64(bencher: &mut Bencher) {
         for y in 0..64 {
             for x in 0..64 {
                 black_box(cell4_range_inv(black_box(&seed), &[x as f32, y as f32, x as f32, y as f32]));
+            }
+        }
+    });
+}
+
+#[bench]
+fn bench_cell2_manhattan_64x64(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| {
+        for y in 0..64 {
+            for x in 0..64 {
+                black_box(cell2_manhattan(black_box(&seed), &[x as f32, y as f32]));
+            }
+        }
+    });
+}
+
+#[bench]
+fn bench_cell3_manhattan_64x64(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| {
+        for y in 0..64 {
+            for x in 0..64 {
+                black_box(cell3_manhattan(black_box(&seed), &[x as f32, y as f32, x as f32]));
+            }
+        }
+    });
+}
+
+#[bench]
+fn bench_cell4_manhattan_64x64(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| {
+        for y in 0..64 {
+            for x in 0..64 {
+                black_box(cell4_manhattan(black_box(&seed), &[x as f32, y as f32, x as f32, y as f32]));
+            }
+        }
+    });
+}
+
+#[bench]
+fn bench_cell2_manhattan_inv_64x64(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| {
+        for y in 0..64 {
+            for x in 0..64 {
+                black_box(cell2_manhattan_inv(black_box(&seed), &[x as f32, y as f32]));
+            }
+        }
+    });
+}
+
+#[bench]
+fn bench_cell3_manhattan_inv_64x64(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| {
+        for y in 0..64 {
+            for x in 0..64 {
+                black_box(cell3_manhattan_inv(black_box(&seed), &[x as f32, y as f32, x as f32]));
+            }
+        }
+    });
+}
+
+#[bench]
+fn bench_cell4_manhattan_inv_64x64(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| {
+        for y in 0..64 {
+            for x in 0..64 {
+                black_box(cell4_manhattan_inv(black_box(&seed), &[x as f32, y as f32, x as f32, y as f32]));
             }
         }
     });

--- a/examples/cell_manhattan.rs
+++ b/examples/cell_manhattan.rs
@@ -1,0 +1,41 @@
+// Copyright 2015 The noise-rs developers. For a full listing of the authors,
+// refer to the AUTHORS file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! An example of using cell range noise
+
+extern crate noise;
+
+use noise::{cell2_manhattan, cell3_manhattan, cell4_manhattan, Seed, Point2};
+
+mod debug;
+
+fn main() {
+    debug::render_png("cell2_manhattan.png", &Seed::new(0), 256, 256, scaled_cell2_manhattan);
+    debug::render_png("cell3_manhattan.png", &Seed::new(0), 256, 256, scaled_cell3_manhattan);
+    debug::render_png("cell4_manhattan.png", &Seed::new(0), 256, 256, scaled_cell4_manhattan);
+    println!("\nGenerated cell2_manhattan.png, cell3_manhattan.png and cell4_manhattan.png");
+}
+
+fn scaled_cell2_manhattan(seed: &Seed, point: &Point2<f32>) -> f32 {
+    cell2_manhattan(seed, &[point[0] / 32.0f32, point[1] / 32.00])
+}
+
+fn scaled_cell3_manhattan(seed: &Seed, point: &Point2<f32>) -> f32 {
+    cell3_manhattan(seed, &[point[0] / 32.0f32, point[1] / 32.00, 0.0])
+}
+
+fn scaled_cell4_manhattan(seed: &Seed, point: &Point2<f32>) -> f32 {
+    cell4_manhattan(seed, &[point[0] / 32.0f32, point[1] / 32.00, 0.0, 0.0])
+}

--- a/examples/cell_manhattan_inv.rs
+++ b/examples/cell_manhattan_inv.rs
@@ -1,0 +1,41 @@
+// Copyright 2015 The noise-rs developers. For a full listing of the authors,
+// refer to the AUTHORS file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! An example of using cell range noise
+
+extern crate noise;
+
+use noise::{cell2_manhattan_inv, cell3_manhattan_inv, cell4_manhattan_inv, Seed, Point2};
+
+mod debug;
+
+fn main() {
+    debug::render_png("cell2_manhattan_inv.png", &Seed::new(0), 256, 256, scaled_cell2_manhattan_inv);
+    debug::render_png("cell3_manhattan_inv.png", &Seed::new(0), 256, 256, scaled_cell3_manhattan_inv);
+    debug::render_png("cell4_manhattan_inv.png", &Seed::new(0), 256, 256, scaled_cell4_manhattan_inv);
+    println!("\nGenerated cell2_manhattan_inv.png, cell3_manhattan_inv.png and cell4_manhattan_inv.png");
+}
+
+fn scaled_cell2_manhattan_inv(seed: &Seed, point: &Point2<f32>) -> f32 {
+    cell2_manhattan_inv(seed, &[point[0] / 32.0f32, point[1] / 32.00])
+}
+
+fn scaled_cell3_manhattan_inv(seed: &Seed, point: &Point2<f32>) -> f32 {
+    cell3_manhattan_inv(seed, &[point[0] / 32.0f32, point[1] / 32.00, 0.0])
+}
+
+fn scaled_cell4_manhattan_inv(seed: &Seed, point: &Point2<f32>) -> f32 {
+    cell4_manhattan_inv(seed, &[point[0] / 32.0f32, point[1] / 32.00, 0.0, 0.0])
+}

--- a/examples/cell_manhattan_value.rs
+++ b/examples/cell_manhattan_value.rs
@@ -1,0 +1,41 @@
+// Copyright 2015 The noise-rs developers. For a full listing of the authors,
+// refer to the AUTHORS file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! An example of using cell range noise
+
+extern crate noise;
+
+use noise::{cell2_manhattan_value, cell3_manhattan_value, cell4_manhattan_value, Seed, Point2};
+
+mod debug;
+
+fn main() {
+    debug::render_png("cell2_manhattan_value.png", &Seed::new(0), 256, 256, scaled_cell2_manhattan_value);
+    debug::render_png("cell3_manhattan_value.png", &Seed::new(0), 256, 256, scaled_cell3_manhattan_value);
+    debug::render_png("cell4_manhattan_value.png", &Seed::new(0), 256, 256, scaled_cell4_manhattan_value);
+    println!("\nGenerated cell2_manhattan_value.png, cell3_manhattan_value.png and cell4_manhattan_value.png");
+}
+
+fn scaled_cell2_manhattan_value(seed: &Seed, point: &Point2<f32>) -> f32 {
+    cell2_manhattan_value(seed, &[point[0] / 32.0f32, point[1] / 32.00])
+}
+
+fn scaled_cell3_manhattan_value(seed: &Seed, point: &Point2<f32>) -> f32 {
+    cell3_manhattan_value(seed, &[point[0] / 32.0f32, point[1] / 32.00, 0.0])
+}
+
+fn scaled_cell4_manhattan_value(seed: &Seed, point: &Point2<f32>) -> f32 {
+    cell4_manhattan_value(seed, &[point[0] / 32.0f32, point[1] / 32.00, 0.0, 0.0])
+}

--- a/examples/cell_range.rs
+++ b/examples/cell_range.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The noise-rs developers. For a full listing of the authors,
+// Copyright 2015 The noise-rs developers. For a full listing of the authors,
 // refer to the AUTHORS file at the top-level directory of this distribution.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/cell_range_inv.rs
+++ b/examples/cell_range_inv.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The noise-rs developers. For a full listing of the authors,
+// Copyright 2015 The noise-rs developers. For a full listing of the authors,
 // refer to the AUTHORS file at the top-level directory of this distribution.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/cell_value.rs
+++ b/examples/cell_value.rs
@@ -1,0 +1,41 @@
+// Copyright 2015 The noise-rs developers. For a full listing of the authors,
+// refer to the AUTHORS file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! An example of using cell range noise
+
+extern crate noise;
+
+use noise::{cell2_value, cell3_value, cell4_value, Seed, Point2};
+
+mod debug;
+
+fn main() {
+    debug::render_png("cell2_value.png", &Seed::new(0), 256, 256, scaled_cell2_value);
+    debug::render_png("cell3_value.png", &Seed::new(0), 256, 256, scaled_cell3_value);
+    debug::render_png("cell4_value.png", &Seed::new(0), 256, 256, scaled_cell4_value);
+    println!("\nGenerated cell2_value.png, cell3_value.png and cell4_value.png");
+}
+
+fn scaled_cell2_value(seed: &Seed, point: &Point2<f32>) -> f32 {
+    cell2_value(seed, &[point[0] / 32.0f32, point[1] / 32.00])
+}
+
+fn scaled_cell3_value(seed: &Seed, point: &Point2<f32>) -> f32 {
+    cell3_value(seed, &[point[0] / 32.0f32, point[1] / 32.00, 0.0])
+}
+
+fn scaled_cell4_value(seed: &Seed, point: &Point2<f32>) -> f32 {
+    cell4_value(seed, &[point[0] / 32.0f32, point[1] / 32.00, 0.0, 0.0])
+}

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -72,6 +72,24 @@ pub fn range_sqr_euclidian4<T: Float>(p1: math::Point4<T>, p2: math::Point4<T>) 
 }
 
 #[inline(always)]
+pub fn range_manhattan2<T: Float>(p1: math::Point2<T>, p2: math::Point2<T>) -> T {
+    let offset = math::sub2(p1, p2);
+    offset[0].abs() + offset[1].abs()
+}
+
+#[inline(always)]
+pub fn range_manhattan3<T: Float>(p1: math::Point3<T>, p2: math::Point3<T>) -> T {
+    let offset = math::sub3(p1, p2);
+    offset[0].abs() + offset[1].abs() + offset[2].abs()
+}
+
+#[inline(always)]
+pub fn range_manhattan4<T: Float>(p1: math::Point4<T>, p2: math::Point4<T>) -> T {
+    let offset = math::sub4(p1, p2);
+    offset[0].abs() + offset[1].abs() + offset[2].abs() + offset[3].abs()
+}
+
+#[inline(always)]
 pub fn cell2_seed_point<T, F>(seed: &Seed, point: &math::Point2<T>, range_func: F) -> (math::Point2<T>, T)
     where T: Float, F: Fn(math::Point2<T>, math::Point2<T>) -> T
 {
@@ -275,5 +293,35 @@ pub fn cell3_range_inv<T: Float>(seed: &Seed, point: &math::Point3<T>) -> T {
 
 pub fn cell4_range_inv<T: Float>(seed: &Seed, point: &math::Point4<T>) -> T {
     let (_, range1, _, range2) = cell4_seed_2_points(seed, point, range_sqr_euclidian4);
+    range2 - range1
+}
+
+pub fn cell2_manhattan<T: Float>(seed: &Seed, point: &math::Point2<T>) -> T {
+    let (_, range) = cell2_seed_point(seed, point, range_manhattan2);
+    range
+}
+
+pub fn cell3_manhattan<T: Float>(seed: &Seed, point: &math::Point3<T>) -> T {
+    let (_, range) = cell3_seed_point(seed, point, range_manhattan3);
+    range
+}
+
+pub fn cell4_manhattan<T: Float>(seed: &Seed, point: &math::Point4<T>) -> T {
+    let (_, range) = cell4_seed_point(seed, point, range_manhattan4);
+    range
+}
+
+pub fn cell2_manhattan_inv<T: Float>(seed: &Seed, point: &math::Point2<T>) -> T {
+    let (_, range1, _, range2) = cell2_seed_2_points(seed, point, range_manhattan2);
+    range2 - range1
+}
+
+pub fn cell3_manhattan_inv<T: Float>(seed: &Seed, point: &math::Point3<T>) -> T {
+    let (_, range1, _, range2) = cell3_seed_2_points(seed, point, range_manhattan3);
+    range2 - range1
+}
+
+pub fn cell4_manhattan_inv<T: Float>(seed: &Seed, point: &math::Point4<T>) -> T {
+    let (_, range1, _, range2) = cell4_seed_2_points(seed, point, range_manhattan4);
     range2 - range1
 }

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -415,3 +415,18 @@ pub fn cell4_manhattan_inv<T: Float>(seed: &Seed, point: &math::Point4<T>) -> T 
     let (_, range1, _, range2) = cell4_seed_2_points(seed, point, range_manhattan4);
     range2 - range1
 }
+
+pub fn cell2_manhattan_value<T: Float>(seed: &Seed, point: &math::Point2<T>) -> T {
+    let cell = cell2_seed_cell(seed, point, range_manhattan2);
+    math::cast::<_,T>(seed.get2(cell)) * math::cast(1.0 / 255.0)
+}
+
+pub fn cell3_manhattan_value<T: Float>(seed: &Seed, point: &math::Point3<T>) -> T {
+    let cell = cell3_seed_cell(seed, point, range_manhattan3);
+    math::cast::<_,T>(seed.get3(cell)) * math::cast(1.0 / 255.0)
+}
+
+pub fn cell4_manhattan_value<T: Float>(seed: &Seed, point: &math::Point4<T>) -> T {
+    let cell = cell4_seed_cell(seed, point, range_manhattan4);
+    math::cast::<_,T>(seed.get4(cell)) * math::cast(1.0 / 255.0)
+}

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -266,6 +266,81 @@ pub fn cell4_seed_2_points<T, F>(seed: &Seed, point: &math::Point4<T>, range_fun
     (seed_point1, range1, seed_point2, range2)
 }
 
+#[inline(always)]
+pub fn cell2_seed_cell<T, F>(seed: &Seed, point: &math::Point2<T>, range_func: F) -> math::Point2<i64>
+    where T: Float, F: Fn(math::Point2<T>, math::Point2<T>) -> T
+{
+    let cell = get_cell2(*point);
+    let mut range: T = Float::max_value();
+    let mut seed_cell: math::Point2<i64> = [0, 0];
+
+    for x_offset in -1..2 {
+        for y_offset in -1..2 {
+            let cell = math::add2(cell, math::cast2([x_offset, y_offset]));
+            let cur_seed_point = get_cell_point2(seed, cell);
+            let cur_range = range_func(*point, cur_seed_point);
+            if cur_range < range {
+                range = cur_range;
+                seed_cell = math::cast2(cell);
+            }
+        }
+    }
+
+    seed_cell
+}
+
+#[inline(always)]
+pub fn cell3_seed_cell<T, F>(seed: &Seed, point: &math::Point3<T>, range_func: F) -> math::Point3<i64>
+    where T: Float, F: Fn(math::Point3<T>, math::Point3<T>) -> T
+{
+    let cell = get_cell3(*point);
+    let mut range: T = Float::max_value();
+    let mut seed_cell: math::Point3<i64> = [0, 0, 0];
+
+    for x_offset in -1..2 {
+        for y_offset in -1..2 {
+            for z_offset in -1..2 {
+                let cell = math::add3(cell, math::cast3([x_offset, y_offset, z_offset]));
+                let cur_seed_point = get_cell_point3(seed, cell);
+                let cur_range = range_func(*point, cur_seed_point);
+                if cur_range < range {
+                    range = cur_range;
+                    seed_cell = math::cast3(cell);
+                }
+            }
+        }
+    }
+
+    seed_cell
+}
+
+#[inline(always)]
+pub fn cell4_seed_cell<T, F>(seed: &Seed, point: &math::Point4<T>, range_func: F) -> math::Point4<i64>
+    where T: Float, F: Fn(math::Point4<T>, math::Point4<T>) -> T
+{
+    let cell = get_cell4(*point);
+    let mut range: T = Float::max_value();
+    let mut seed_cell: math::Point4<i64> = [0, 0, 0, 0];
+
+    for x_offset in -1..2 {
+        for y_offset in -1..2 {
+            for z_offset in -1..2 {
+                for w_offset in -1..2 {
+                    let cell = math::add4(cell, math::cast4([x_offset, y_offset, z_offset, w_offset]));
+                    let cur_seed_point = get_cell_point4(seed, cell);
+                    let cur_range = range_func(*point, cur_seed_point);
+                    if cur_range < range {
+                        range = cur_range;
+                        seed_cell = math::cast4(cell);
+                    }
+                }
+            }
+        }
+    }
+
+    seed_cell
+}
+
 pub fn cell2_range<T: Float>(seed: &Seed, point: &math::Point2<T>) -> T {
     let (_, range) = cell2_seed_point(seed, point, range_sqr_euclidian2);
     range
@@ -294,6 +369,21 @@ pub fn cell3_range_inv<T: Float>(seed: &Seed, point: &math::Point3<T>) -> T {
 pub fn cell4_range_inv<T: Float>(seed: &Seed, point: &math::Point4<T>) -> T {
     let (_, range1, _, range2) = cell4_seed_2_points(seed, point, range_sqr_euclidian4);
     range2 - range1
+}
+
+pub fn cell2_value<T: Float>(seed: &Seed, point: &math::Point2<T>) -> T {
+    let cell = cell2_seed_cell(seed, point, range_sqr_euclidian2);
+    math::cast::<_,T>(seed.get2(cell)) * math::cast(1.0 / 255.0)
+}
+
+pub fn cell3_value<T: Float>(seed: &Seed, point: &math::Point3<T>) -> T {
+    let cell = cell3_seed_cell(seed, point, range_sqr_euclidian3);
+    math::cast::<_,T>(seed.get3(cell)) * math::cast(1.0 / 255.0)
+}
+
+pub fn cell4_value<T: Float>(seed: &Seed, point: &math::Point4<T>) -> T {
+    let cell = cell4_seed_cell(seed, point, range_sqr_euclidian4);
+    math::cast::<_,T>(seed.get4(cell)) * math::cast(1.0 / 255.0)
 }
 
 pub fn cell2_manhattan<T: Float>(seed: &Seed, point: &math::Point2<T>) -> T {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,8 @@ pub use cell::{range_sqr_euclidian2, range_sqr_euclidian3, range_sqr_euclidian4}
 pub use cell::{cell2_seed_point, cell3_seed_point, cell4_seed_point};
 pub use cell::{cell2_range, cell3_range, cell4_range};
 pub use cell::{cell2_range_inv, cell3_range_inv, cell4_range_inv};
+pub use cell::{cell2_manhattan, cell3_manhattan, cell4_manhattan};
+pub use cell::{cell2_manhattan_inv, cell3_manhattan_inv, cell4_manhattan_inv};
 
 mod gradient;
 mod math;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub use cell::{range_sqr_euclidian2, range_sqr_euclidian3, range_sqr_euclidian4}
 pub use cell::{cell2_seed_point, cell3_seed_point, cell4_seed_point};
 pub use cell::{cell2_range, cell3_range, cell4_range};
 pub use cell::{cell2_range_inv, cell3_range_inv, cell4_range_inv};
+pub use cell::{cell2_value, cell3_value, cell4_value};
 pub use cell::{cell2_manhattan, cell3_manhattan, cell4_manhattan};
 pub use cell::{cell2_manhattan_inv, cell3_manhattan_inv, cell4_manhattan_inv};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub use cell::{cell2_range_inv, cell3_range_inv, cell4_range_inv};
 pub use cell::{cell2_value, cell3_value, cell4_value};
 pub use cell::{cell2_manhattan, cell3_manhattan, cell4_manhattan};
 pub use cell::{cell2_manhattan_inv, cell3_manhattan_inv, cell4_manhattan_inv};
+pub use cell::{cell2_manhattan_value, cell3_manhattan_value, cell4_manhattan_value};
 
 mod gradient;
 mod math;


### PR DESCRIPTION
This adds all the manhattan and value cell noise types.

Manhattan noise uses a different range function, achieved by adding together the elements of vector.

Cell value assigns a random value to the entire space of each cell, instead of returning a range to the seed point or edge.