### PR TITLE
Clean up and further optimize the single point cell seed functions.

### DIFF
--- a/src/cell.rs
+++ b/src/cell.rs
@@ -183,6 +183,7 @@ pub fn get_vec4<T: Float>(index: usize) -> math::Point4<T> {
 pub fn cell2_seed_point<T, F>(seed: &Seed, point: &math::Point2<T>, range_func: F) -> (math::Point2<T>, T)
     where T: Float, F: Fn(math::Point2<T>, math::Point2<T>) -> T
 {
+    #[inline(always)]
     fn get_point<T: Float>(seed: &Seed, whole: math::Point2<isize>) -> math::Point2<T> {
         math::add2(get_vec2(seed.get2(whole)), math::cast2::<_,T>(whole))
     }
@@ -190,31 +191,35 @@ pub fn cell2_seed_point<T, F>(seed: &Seed, point: &math::Point2<T>, range_func: 
     let whole0  = math::map2(*point, math::cast);
     let whole1  = math::add2(whole0, math::one2());
 
-    let p00 = get_point(seed, [whole0[0], whole0[1]]);
-    let p10 = get_point(seed, [whole1[0], whole0[1]]);
-    let p01 = get_point(seed, [whole0[0], whole1[1]]);
-    let p11 = get_point(seed, [whole1[0], whole1[1]]);
+    let mut range: T = Float::max_value();
+    let mut seed_point = math::zero2::<T>();
 
-    let r00 = range_func(*point, p00);
-    let r10 = range_func(*point, p10);
-    let r01 = range_func(*point, p01);
-    let r11 = range_func(*point, p11);
+    macro_rules! test_point(
+        [$x:expr, $y:expr] => {
+            {
+                let cur_point = get_point(seed, [$x, $y]);
+                let cur_range = range_func(*point, cur_point);
+                if cur_range < range {
+                    range = cur_range;
+                    seed_point = cur_point;
+                }
+            }
+        }
+    );
 
-    if r00 < r10 && r00 < r01 && r00 < r11 {
-        (p00, r00)
-    } else if r10 < r01 && r10 < r11 {
-        (p10, r10)
-    } else if r01 < r11 {
-        (p01, r01)
-    } else {
-        (p11, r11)
-    }
+    test_point![whole0[0], whole0[1]];
+    test_point![whole1[0], whole0[1]];
+    test_point![whole0[0], whole1[1]];
+    test_point![whole1[0], whole1[1]];
+
+    (seed_point, range)
 }
 
 #[inline(always)]
 pub fn cell3_seed_point<T, F>(seed: &Seed, point: &math::Point3<T>, range_func: F) -> (math::Point3<T>, T)
     where T: Float, F: Fn(math::Point3<T>, math::Point3<T>) -> T
 {
+    #[inline(always)]
     fn get_point<T: Float>(seed: &Seed, whole: math::Point3<isize>) -> math::Point3<T> {
         math::add3(get_vec3(seed.get3(whole)), math::cast3::<_,T>(whole))
     }
@@ -222,47 +227,39 @@ pub fn cell3_seed_point<T, F>(seed: &Seed, point: &math::Point3<T>, range_func: 
     let whole0  = math::map3(*point, math::cast);
     let whole1  = math::add3(whole0, math::one3());
 
-    let p000 = get_point(seed, [whole0[0], whole0[1], whole0[2]]);
-    let p100 = get_point(seed, [whole1[0], whole0[1], whole0[2]]);
-    let p010 = get_point(seed, [whole0[0], whole1[1], whole0[2]]);
-    let p110 = get_point(seed, [whole1[0], whole1[1], whole0[2]]);
-    let p001 = get_point(seed, [whole0[0], whole0[1], whole1[2]]);
-    let p101 = get_point(seed, [whole1[0], whole0[1], whole1[2]]);
-    let p011 = get_point(seed, [whole0[0], whole1[1], whole1[2]]);
-    let p111 = get_point(seed, [whole1[0], whole1[1], whole1[2]]);
+    let mut range: T = Float::max_value();
+    let mut seed_point = math::zero3::<T>();
 
-    let r000 = range_func(*point, p000);
-    let r100 = range_func(*point, p100);
-    let r010 = range_func(*point, p010);
-    let r110 = range_func(*point, p110);
-    let r001 = range_func(*point, p001);
-    let r101 = range_func(*point, p101);
-    let r011 = range_func(*point, p011);
-    let r111 = range_func(*point, p111);
+    macro_rules! test_point(
+        [$x:expr, $y:expr, $z:expr] => {
+            {
+                let cur_point = get_point(seed, [$x, $y, $z]);
+                let cur_range = range_func(*point, cur_point);
+                if cur_range < range {
+                    range = cur_range;
+                    seed_point = cur_point;
+                }
+            }
+        }
+    );
 
-    if r000 < r100 && r000 < r010 && r000 < r110 && r000 < r001 && r000 < r101 && r000 < r011 && r000 < r111 {
-        (p000, r000)
-    } else if r100 < r010 && r100 < r110 && r100 < r001 && r100 < r101 && r100 < r011 && r100 < r111 {
-        (p100, r100)
-    } else if r010 < r110 && r010 < r001 && r010 < r101 && r010 < r011 && r010 < r111 {
-        (p010, r010)
-    } else if r110 < r001 && r110 < r101 && r110 < r011 && r110 < r111 {
-        (p110, r110)
-    } else if r001 < r101 && r001 < r011 && r001 < r111 {
-        (p001, r001)
-    } else if r101 < r011 && r101 < r111 {
-        (p101, r101)
-    } else if r011 < r111 {
-        (p011, r011)
-    } else {
-        (p111, r111)
-    }
+    test_point![whole0[0], whole0[1], whole0[2]];
+    test_point![whole1[0], whole0[1], whole0[2]];
+    test_point![whole0[0], whole1[1], whole0[2]];
+    test_point![whole1[0], whole1[1], whole0[2]];
+    test_point![whole0[0], whole0[1], whole1[2]];
+    test_point![whole1[0], whole0[1], whole1[2]];
+    test_point![whole0[0], whole1[1], whole1[2]];
+    test_point![whole1[0], whole1[1], whole1[2]];
+
+    (seed_point, range)
 }
 
 #[inline(always)]
 pub fn cell4_seed_point<T, F>(seed: &Seed, point: &math::Point4<T>, range_func: F) -> (math::Point4<T>, T)
     where T: Float, F: Fn(math::Point4<T>, math::Point4<T>) -> T
 {
+    #[inline(always)]
     fn get_point<T: Float>(seed: &Seed, whole: math::Point4<isize>) -> math::Point4<T> {
         math::add4(get_vec4(seed.get4(whole)), math::cast4::<_,T>(whole))
     }
@@ -270,81 +267,40 @@ pub fn cell4_seed_point<T, F>(seed: &Seed, point: &math::Point4<T>, range_func: 
     let whole0  = math::map4(*point, math::cast);
     let whole1  = math::add4(whole0, math::one4());
 
-    let p0000 = get_point(seed, [whole0[0], whole0[1], whole0[2], whole0[3]]);
-    let p1000 = get_point(seed, [whole1[0], whole0[1], whole0[2], whole0[3]]);
-    let p0100 = get_point(seed, [whole0[0], whole1[1], whole0[2], whole0[3]]);
-    let p1100 = get_point(seed, [whole1[0], whole1[1], whole0[2], whole0[3]]);
-    let p0010 = get_point(seed, [whole0[0], whole0[1], whole1[2], whole0[3]]);
-    let p1010 = get_point(seed, [whole1[0], whole0[1], whole1[2], whole0[3]]);
-    let p0110 = get_point(seed, [whole0[0], whole1[1], whole1[2], whole0[3]]);
-    let p1110 = get_point(seed, [whole1[0], whole1[1], whole1[2], whole0[3]]);
-    let p0001 = get_point(seed, [whole0[0], whole0[1], whole0[2], whole1[3]]);
-    let p1001 = get_point(seed, [whole1[0], whole0[1], whole0[2], whole1[3]]);
-    let p0101 = get_point(seed, [whole0[0], whole1[1], whole0[2], whole1[3]]);
-    let p1101 = get_point(seed, [whole1[0], whole1[1], whole0[2], whole1[3]]);
-    let p0011 = get_point(seed, [whole0[0], whole0[1], whole1[2], whole1[3]]);
-    let p1011 = get_point(seed, [whole1[0], whole0[1], whole1[2], whole1[3]]);
-    let p0111 = get_point(seed, [whole0[0], whole1[1], whole1[2], whole1[3]]);
-    let p1111 = get_point(seed, [whole1[0], whole1[1], whole1[2], whole1[3]]);
+    let mut range: T = Float::max_value();
+    let mut seed_point = math::zero4::<T>();
 
-    let r0000 = range_func(*point, p0000);
-    let r1000 = range_func(*point, p1000);
-    let r0100 = range_func(*point, p0100);
-    let r1100 = range_func(*point, p1100);
-    let r0010 = range_func(*point, p0010);
-    let r1010 = range_func(*point, p1010);
-    let r0110 = range_func(*point, p0110);
-    let r1110 = range_func(*point, p1110);
-    let r0001 = range_func(*point, p0001);
-    let r1001 = range_func(*point, p1001);
-    let r0101 = range_func(*point, p0101);
-    let r1101 = range_func(*point, p1101);
-    let r0011 = range_func(*point, p0011);
-    let r1011 = range_func(*point, p1011);
-    let r0111 = range_func(*point, p0111);
-    let r1111 = range_func(*point, p1111);
+    macro_rules! test_point(
+        [$x:expr, $y:expr, $z:expr, $w:expr] => {
+            {
+                let cur_point = get_point(seed, [$x, $y, $z, $w]);
+                let cur_range = range_func(*point, cur_point);
+                if cur_range < range {
+                    range = cur_range;
+                    seed_point = cur_point;
+                }
+            }
+        }
+    );
 
-    if r0000 < r1000 && r0000 < r0100 && r0000 < r1100 && r0000 < r0010 && r0000 < r1010 && r0000 < r0110 && r0000 < r1110 &&
-        r0000 < r0001 && r0000 < r1001 && r0000 < r0101 && r0000 < r1101 && r0000 < r0011 && r0000 < r1011 && r0000 < r0111 && r0000 < r1111 {
-        (p0000, r0000)
-    } else if r1000 < r0100 && r1000 < r1100 && r1000 < r0010 && r1000 < r1010 && r1000 < r0110 && r1000 < r1110 && r1000 < r0001 &&
-        r1000 < r1001 && r1000 < r0101 && r1000 < r1101 && r1000 < r0011 && r1000 < r1011 && r1000 < r0111 && r1000 < r1111 {
-        (p1000, r1000)
-    } else if r0100 < r1100 && r0100 < r0010 && r0100 < r1010 && r0100 < r0110 && r0100 < r1110 && r0100 < r0001 && r0100 < r1001 &&
-        r0100 < r0101 && r0100 < r1101 && r0100 < r0011 && r0100 < r1011 && r0100 < r0111 && r0100 < r1111 {
-        (p0100, r0100)
-    } else if r1100 < r0010 && r1100 < r1010 && r1100 < r0110 && r1100 < r1110 && r1100 < r0001 && r1100 < r1001 && r1100 < r0101 &&
-        r1100 < r1101 && r1100 < r0011 && r1100 < r1011 && r1100 < r0111 && r1100 < r1111 {
-        (p1100, r1100)
-    } else if r0010 < r1010 && r0010 < r0110 && r0010 < r1110 && r0010 < r0001 && r0010 < r1001 && r0010 < r0101 && r0010 < r1101 &&
-        r0010 < r0011 && r0010 < r1011 && r0010 < r0111 && r0010 < r1111 {
-        (p0010, r0010)
-    } else if r1010 < r0110 && r1010 < r1110 && r1010 < r0001 && r1010 < r1001 && r1010 < r0101 && r1010 < r1101 && r1010 < r0011 &&
-        r1010 < r1011 && r1010 < r0111 && r1010 < r1111 {
-        (p1010, r1010)
-    } else if r0110 < r1110 && r0110 < r0001 && r0110 < r1001 && r0110 < r0101 && r0110 < r1101 && r0110 < r0011 && r0110 < r1011 &&
-        r0110 < r0111 && r0110 < r1111 {
-        (p0110, r0110)
-    } else if r1110 < r0001 && r1110 < r1001 && r1110 < r0101 && r1110 < r1101 && r1110 < r0011 && r1110 < r1011 && r1110 < r0111 &&
-        r1110 < r1111 {
-        (p1110, r1110)
-    } else if r0001 < r1001 && r0001 < r0101 && r0001 < r1101 && r0001 < r0011 && r0001 < r1011 && r0001 < r0111 && r0001 < r1111 {
-        (p0001, r0001)
-    } else if r1001 < r0101 && r1001 < r1101 && r1001 < r0011 && r1001 < r1011 && r1001 < r0111 && r1001 < r1111 {
-        (p1001, r1001)
-    } else if r0101 < r1101 && r0101 < r0011 && r0101 < r1011 && r0101 < r0111 && r0101 < r1111 {
-        (p0101, r0101)
-    } else if r1101 < r0011 && r1101 < r1011 && r1101 < r0111 && r1101 < r1111 {
-        (p1101, r1101)
-    } else if r0011 < r1011 && r0011 < r0111 && r0011 < r1111 {
-        (p0011, r0011)
-    } else if r1011 < r0111 && r1011 < r1111 {
-        (p1011, r1011)
-    } else if r0111 < r1111 {
-        (p0111, r0111)
-    } else {
-        (p1111, r1111)
-    }
+    test_point![whole0[0], whole0[1], whole0[2], whole0[3]];
+    test_point![whole1[0], whole0[1], whole0[2], whole0[3]];
+    test_point![whole0[0], whole1[1], whole0[2], whole0[3]];
+    test_point![whole1[0], whole1[1], whole0[2], whole0[3]];
+    test_point![whole0[0], whole0[1], whole1[2], whole0[3]];
+    test_point![whole1[0], whole0[1], whole1[2], whole0[3]];
+    test_point![whole0[0], whole1[1], whole1[2], whole0[3]];
+    test_point![whole1[0], whole1[1], whole1[2], whole0[3]];
+    test_point![whole0[0], whole0[1], whole0[2], whole1[3]];
+    test_point![whole1[0], whole0[1], whole0[2], whole1[3]];
+    test_point![whole0[0], whole1[1], whole0[2], whole1[3]];
+    test_point![whole1[0], whole1[1], whole0[2], whole1[3]];
+    test_point![whole0[0], whole0[1], whole1[2], whole1[3]];
+    test_point![whole1[0], whole0[1], whole1[2], whole1[3]];
+    test_point![whole0[0], whole1[1], whole1[2], whole1[3]];
+    test_point![whole1[0], whole1[1], whole1[2], whole1[3]];
+
+    (seed_point, range)
 }
 
 #[inline(always)]

--- a/src/math.rs
+++ b/src/math.rs
@@ -83,6 +83,10 @@ pub fn one2<T: Copy + NumCast>() -> Vector2<T> { cast2(const2(1)) }
 pub fn one3<T: Copy + NumCast>() -> Vector3<T> { cast3(const3(1)) }
 pub fn one4<T: Copy + NumCast>() -> Vector4<T> { cast4(const4(1)) }
 
+pub fn zero2<T: Copy + NumCast>() -> Vector2<T> { cast2(const2(0)) }
+pub fn zero3<T: Copy + NumCast>() -> Vector3<T> { cast3(const3(0)) }
+pub fn zero4<T: Copy + NumCast>() -> Vector4<T> { cast4(const4(0)) }
+
 pub fn cast2<T: NumCast + Copy, U: NumCast + Copy>(x: Point2<T>) -> Point2<U> { map2(x, cast) }
 pub fn cast3<T: NumCast + Copy, U: NumCast + Copy>(x: Point3<T>) -> Point3<U> { map3(x, cast) }
 pub fn cast4<T: NumCast + Copy, U: NumCast + Copy>(x: Point4<T>) -> Point4<U> { map4(x, cast) }


### PR DESCRIPTION
The addition of #[inline(always)] on their local get_point() functions significantly improved the performance of cell3_range and cell4_range.