### PR TITLE
Fix negative perlin noise.

### DIFF
--- a/examples/debug/mod.rs
+++ b/examples/debug/mod.rs
@@ -42,7 +42,7 @@ pub fn render_png<T, F>(filename: &str, seed: &noise::Seed, width: u32, height: 
 
     for y in (0..height) {
         for x in (0..width) {
-            let value: f32 = cast(func(seed, &[cast(x), cast(y)]));
+            let value: f32 = cast(func(seed, &[cast::<_,T>(x) - cast::<_,T>(width/2), cast::<_,T>(y) - cast::<_,T>(height/2)]));
             pixels.push(cast(clamp(value * 0.5 + 0.5, 0.0, 1.0) * 255.0));
         }
     }

--- a/src/perlin.rs
+++ b/src/perlin.rs
@@ -30,7 +30,7 @@ pub fn perlin2<T: Float>(seed: &Seed, point: &math::Point2<T>) -> T {
     }
 
     let floored = math::map2(*point, Float::floor);
-    let whole0  = math::map2(*point, math::cast);
+    let whole0  = math::map2(floored, math::cast);
     let whole1  = math::add2(whole0, math::one2());
     let frac0   = math::sub2(*point, floored);
     let frac1   = math::sub2(frac0, math::one2());
@@ -57,7 +57,7 @@ pub fn perlin3<T: Float>(seed: &Seed, point: &math::Point3<T>) -> T {
     }
 
     let floored = math::map3(*point, Float::floor);
-    let whole0  = math::map3(*point, math::cast);
+    let whole0  = math::map3(floored, math::cast);
     let whole1  = math::add3(whole0, math::one3());
     let frac0   = math::sub3(*point, floored);
     let frac1   = math::sub3(frac0, math::one3());
@@ -88,7 +88,7 @@ pub fn perlin4<T: Float>(seed: &Seed, point: &math::Point4<T>) -> T {
     }
 
     let floored = math::map4(*point, Float::floor);
-    let whole0  = math::map4(*point, math::cast);
+    let whole0  = math::map4(floored, math::cast);
     let whole1  = math::add4(whole0, math::one4());
     let frac0   = math::sub4(*point, floored);
     let frac1   = math::sub4(frac0, math::one4());


### PR DESCRIPTION
Perlin noise on negative coordinates was generating discontinuities, because we were casting the coordinates to int instead of flooring them. Flooring always rounds down, whereas casting to int merely truncates, which with a negative number actually rounds up.