### PR TITLE
Update for rust 2015-02-04

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,9 @@ name = "cell_manhattan_value"
 
 name = "benches"
 
+[dependencies]
+rand = "0.1"
+
 [dev-dependencies]
 
 image = "*"

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -15,7 +15,8 @@
 //! An example of using simplectic noise
 
 #![feature(asm)]
-#![allow(unstable)]
+#![feature(core)]
+#![feature(test)]
 
 extern crate noise;
 extern crate test;

--- a/examples/brownian.rs
+++ b/examples/brownian.rs
@@ -14,6 +14,8 @@
 
 //! An example of using fractal brownian motion on perlin noise
 
+#![feature(core)]
+#![feature(path)]
 #![feature(unboxed_closures)]
 
 extern crate noise;

--- a/examples/cell_manhattan.rs
+++ b/examples/cell_manhattan.rs
@@ -14,6 +14,9 @@
 
 //! An example of using cell range noise
 
+#![feature(core)]
+#![feature(path)]
+
 extern crate noise;
 
 use noise::{cell2_manhattan, cell3_manhattan, cell4_manhattan, Seed, Point2};

--- a/examples/cell_manhattan_inv.rs
+++ b/examples/cell_manhattan_inv.rs
@@ -14,6 +14,9 @@
 
 //! An example of using cell range noise
 
+#![feature(core)]
+#![feature(path)]
+
 extern crate noise;
 
 use noise::{cell2_manhattan_inv, cell3_manhattan_inv, cell4_manhattan_inv, Seed, Point2};

--- a/examples/cell_manhattan_value.rs
+++ b/examples/cell_manhattan_value.rs
@@ -14,6 +14,9 @@
 
 //! An example of using cell range noise
 
+#![feature(core)]
+#![feature(path)]
+
 extern crate noise;
 
 use noise::{cell2_manhattan_value, cell3_manhattan_value, cell4_manhattan_value, Seed, Point2};

--- a/examples/cell_range.rs
+++ b/examples/cell_range.rs
@@ -14,6 +14,9 @@
 
 //! An example of using cell range noise
 
+#![feature(core)]
+#![feature(path)]
+
 extern crate noise;
 
 use noise::{cell2_range, cell3_range, cell4_range, Seed, Point2};

--- a/examples/cell_range_inv.rs
+++ b/examples/cell_range_inv.rs
@@ -14,6 +14,9 @@
 
 //! An example of using cell range noise
 
+#![feature(core)]
+#![feature(path)]
+
 extern crate noise;
 
 use noise::{cell2_range_inv, cell3_range_inv, cell4_range_inv, Seed, Point2};

--- a/examples/cell_value.rs
+++ b/examples/cell_value.rs
@@ -14,6 +14,9 @@
 
 //! An example of using cell range noise
 
+#![feature(core)]
+#![feature(path)]
+
 extern crate noise;
 
 use noise::{cell2_value, cell3_value, cell4_value, Seed, Point2};

--- a/examples/debug/mod.rs
+++ b/examples/debug/mod.rs
@@ -14,8 +14,6 @@
 
 //! Useful things for debugging noise functions.
 
-#![allow(unstable)]
-
 extern crate image;
 
 use noise;

--- a/examples/open_simplex.rs
+++ b/examples/open_simplex.rs
@@ -14,6 +14,9 @@
 
 //! An example of using simplex noise
 
+#![feature(core)]
+#![feature(path)]
+
 extern crate noise;
 
 use noise::{open_simplex2, open_simplex3, Seed, Point2};

--- a/examples/perlin.rs
+++ b/examples/perlin.rs
@@ -14,6 +14,9 @@
 
 //! An example of using perlin noise
 
+#![feature(core)]
+#![feature(path)]
+
 extern crate noise;
 
 use noise::{perlin2, perlin3, perlin4, Seed, Point2};

--- a/src/brownian.rs
+++ b/src/brownian.rs
@@ -32,12 +32,16 @@ use {Point2, Point3, Point4};
 /// # Example
 ///
 /// ```rust
-/// use noise::{Brownian2, perlin2};
-/// use std::rand;
+/// extern crate noise;
+/// extern crate rand;
 ///
+/// use noise::{Brownian2, perlin2};
+///
+/// # fn main() {
 /// let seed = rand::random();
 /// let noise = Brownian2::new(perlin2, 4).wavelength(32.0);
 /// let val = noise(&seed, &[42.0, 37.0]);
+/// # }
 /// ```
 #[derive(Copy, Clone)]
 pub struct Brownian2<T, F: GenFn2<T>> {
@@ -67,12 +71,16 @@ pub struct Brownian2<T, F: GenFn2<T>> {
 /// # Example
 ///
 /// ```rust
-/// use noise::{Brownian3, perlin3};
-/// use std::rand;
+/// extern crate noise;
+/// extern crate rand;
 ///
+/// use noise::{Brownian3, perlin3};
+///
+/// # fn main() {
 /// let seed = rand::random();
 /// let noise = Brownian3::new(perlin3, 4).wavelength(32.0);
 /// let val = noise(&seed, &[42.0, 37.0, 2.0]);
+/// # }
 /// ```
 #[derive(Copy, Clone)]
 pub struct Brownian3<T, F: GenFn3<T>> {
@@ -102,12 +110,16 @@ pub struct Brownian3<T, F: GenFn3<T>> {
 /// # Example
 ///
 /// ```rust
-/// use noise::{Brownian4, perlin4};
-/// use std::rand;
+/// extern crate noise;
+/// extern crate rand;
 ///
+/// use noise::{Brownian4, perlin4};
+///
+/// # fn main() {
 /// let seed = rand::random();
 /// let noise = Brownian4::new(perlin4, 4).wavelength(32.0);
 /// let val = noise(&seed, &[42.0, 37.0, 2.0, 3.0]);
+/// # }
 /// ```
 #[derive(Copy, Clone)]
 pub struct Brownian4<T, F: GenFn4<T>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,9 +24,12 @@
 //! let val = noise(&seed, &[42.0, 37.0, 2.0]);
 //! ```
 
+#![feature(core)]
+#![feature(std_misc)]
 #![feature(unboxed_closures)]
 #![deny(missing_copy_implementations)]
-#![allow(unstable)]
+
+extern crate rand;
 
 pub use seed::Seed;
 pub use math::{Point2, Point3, Point4};

--- a/src/seed.rs
+++ b/src/seed.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::rand::{Rand, Rng, SeedableRng, XorShiftRng};
+use rand::{Rand, Rng, SeedableRng, XorShiftRng};
 use std::num::SignedInt;
 
 use math;
@@ -34,18 +34,27 @@ impl Rand for Seed {
     /// # Examples
     ///
     /// ```rust
-    /// use noise::Seed;
-    /// use std::rand;
+    /// extern crate noise;
+    /// extern crate rand;
     ///
+    /// use noise::Seed;
+    ///
+    /// # fn main() {
     /// let seed = rand::random::<Seed>();
+    /// # }
     /// ```
     ///
     /// ```rust
-    /// use noise::Seed;
-    /// use std::rand::{SeedableRng, Rng, XorShiftRng};
+    /// extern crate noise;
+    /// extern crate rand;
     ///
+    /// use noise::Seed;
+    /// use rand::{SeedableRng, Rng, XorShiftRng};
+    ///
+    /// # fn main() {
     /// let mut rng: XorShiftRng = SeedableRng::from_seed([1, 2, 3, 4]);
     /// let seed = rng.gen::<Seed>();
+    /// # }
     /// ```
     fn rand<R: Rng>(rng: &mut R) -> Seed {
         let mut seq: Vec<u8> = ::std::iter::range_inclusive(0, (TABLE_SIZE - 1) as u8).collect();
@@ -106,7 +115,7 @@ impl Seed {
 
 #[cfg(test)]
 mod tests {
-    use std::rand::random;
+    use rand::random;
     use perlin::perlin3;
     use super::Seed;
 


### PR DESCRIPTION
Switch to rand crate and use features instead of #![allow(unstable)]. This won't build until image is updated on crates.io but it does work with zero warnings if you manually override that dependency.