### PR TITLE
rustup

### DIFF
--- a/examples/brownian.rs
+++ b/examples/brownian.rs
@@ -15,7 +15,6 @@
 //! An example of using fractal brownian motion on perlin noise
 
 #![feature(core)]
-#![feature(path)]
 #![feature(unboxed_closures)]
 
 extern crate noise;

--- a/examples/cell_manhattan.rs
+++ b/examples/cell_manhattan.rs
@@ -15,7 +15,6 @@
 //! An example of using cell range noise
 
 #![feature(core)]
-#![feature(path)]
 
 extern crate noise;
 

--- a/examples/cell_manhattan_inv.rs
+++ b/examples/cell_manhattan_inv.rs
@@ -15,7 +15,6 @@
 //! An example of using cell range noise
 
 #![feature(core)]
-#![feature(path)]
 
 extern crate noise;
 

--- a/examples/cell_manhattan_value.rs
+++ b/examples/cell_manhattan_value.rs
@@ -15,7 +15,6 @@
 //! An example of using cell range noise
 
 #![feature(core)]
-#![feature(path)]
 
 extern crate noise;
 

--- a/examples/cell_range.rs
+++ b/examples/cell_range.rs
@@ -15,7 +15,6 @@
 //! An example of using cell range noise
 
 #![feature(core)]
-#![feature(path)]
 
 extern crate noise;
 

--- a/examples/cell_range_inv.rs
+++ b/examples/cell_range_inv.rs
@@ -15,7 +15,6 @@
 //! An example of using cell range noise
 
 #![feature(core)]
-#![feature(path)]
 
 extern crate noise;
 

--- a/examples/cell_value.rs
+++ b/examples/cell_value.rs
@@ -15,7 +15,6 @@
 //! An example of using cell range noise
 
 #![feature(core)]
-#![feature(path)]
 
 extern crate noise;
 

--- a/examples/debug/mod.rs
+++ b/examples/debug/mod.rs
@@ -17,6 +17,7 @@
 extern crate image;
 
 use noise;
+use std::path::Path;
 use std::num::{self, Float, NumCast};
 
 fn cast<T: NumCast, R: NumCast>(val: T) -> R {

--- a/examples/open_simplex.rs
+++ b/examples/open_simplex.rs
@@ -15,7 +15,6 @@
 //! An example of using simplex noise
 
 #![feature(core)]
-#![feature(path)]
 
 extern crate noise;
 

--- a/examples/perlin.rs
+++ b/examples/perlin.rs
@@ -15,7 +15,6 @@
 //! An example of using perlin noise
 
 #![feature(core)]
-#![feature(path)]
 
 extern crate noise;
 

--- a/src/brownian.rs
+++ b/src/brownian.rs
@@ -213,7 +213,6 @@ impl<'a, 'b, T, F> Fn<(&'a Seed, &'b Point2<T>)> for Brownian2<T, F> where
     T: Float,
     F: GenFn2<T>,
 {
-    type Output = T;
     /// Applies the brownian noise function for the supplied seed and point.
     extern "rust-call" fn call(&self, (seed, point): (&'a Seed, &'b Point2<T>)) -> T {
         let mut frequency: T = self.frequency;
@@ -230,11 +229,29 @@ impl<'a, 'b, T, F> Fn<(&'a Seed, &'b Point2<T>)> for Brownian2<T, F> where
     }
 }
 
+impl<'a, 'b, T, F> FnMut<(&'a Seed, &'b Point2<T>)> for Brownian2<T, F> where
+    T: Float,
+    F: GenFn2<T>,
+{
+    extern "rust-call" fn call_mut(&mut self, (seed, point): (&'a Seed, &'b Point2<T>)) -> T {
+        self.call((seed, point))
+    }
+}
+
+impl<'a, 'b, T, F> FnOnce<(&'a Seed, &'b Point2<T>)> for Brownian2<T, F> where
+    T: Float,
+    F: GenFn2<T>,
+{
+    type Output = T;
+    extern "rust-call" fn call_once(self, (seed, point): (&'a Seed, &'b Point2<T>)) -> T {
+        self.call((seed, point))
+    }
+}
+
 impl<'a, 'b, T, F> Fn<(&'a Seed, &'b Point3<T>)> for Brownian3<T, F> where
     T: Float,
     F: GenFn3<T>,
 {
-    type Output = T;
     /// Applies the brownian noise function for the supplied seed and point.
     extern "rust-call" fn call(&self, (seed, point): (&'a Seed, &'b Point3<T>)) -> T {
         let mut frequency: T = self.frequency;
@@ -252,11 +269,29 @@ impl<'a, 'b, T, F> Fn<(&'a Seed, &'b Point3<T>)> for Brownian3<T, F> where
     }
 }
 
+impl<'a, 'b, T, F> FnMut<(&'a Seed, &'b Point3<T>)> for Brownian3<T, F> where
+    T: Float,
+    F: GenFn3<T>,
+{
+    extern "rust-call" fn call_mut(&mut self, (seed, point): (&'a Seed, &'b Point3<T>)) -> T {
+        self.call((seed, point))
+    }
+}
+
+impl<'a, 'b, T, F> FnOnce<(&'a Seed, &'b Point3<T>)> for Brownian3<T, F> where
+    T: Float,
+    F: GenFn3<T>,
+{
+    type Output = T;
+    extern "rust-call" fn call_once(self, (seed, point): (&'a Seed, &'b Point3<T>)) -> T {
+        self.call((seed, point))
+    }
+}
+
 impl<'a, 'b, T, F> Fn<(&'a Seed, &'b ::Point4<T>)> for Brownian4<T, F> where
     T: Float,
     F: GenFn4<T>,
 {
-    type Output = T;
     /// Applies the brownian noise function for the supplied seed and point.
     extern "rust-call" fn call(&self, (seed, point): (&'a Seed, &'b Point4<T>)) -> T {
         let mut frequency: T = self.frequency;
@@ -272,5 +307,24 @@ impl<'a, 'b, T, F> Fn<(&'a Seed, &'b ::Point4<T>)> for Brownian4<T, F> where
             frequency = frequency * self.lacunarity;
         }
         result
+    }
+}
+
+impl<'a, 'b, T, F> FnMut<(&'a Seed, &'b Point4<T>)> for Brownian4<T, F> where
+    T: Float,
+    F: GenFn4<T>,
+{
+    extern "rust-call" fn call_mut(&mut self, (seed, point): (&'a Seed, &'b Point4<T>)) -> T {
+        self.call((seed, point))
+    }
+}
+
+impl<'a, 'b, T, F> FnOnce<(&'a Seed, &'b Point4<T>)> for Brownian4<T, F> where
+    T: Float,
+    F: GenFn4<T>,
+{
+    type Output = T;
+    extern "rust-call" fn call_once(self, (seed, point): (&'a Seed, &'b Point4<T>)) -> T {
+        self.call((seed, point))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@
 //! ```
 
 #![feature(core)]
+#![feature(slice_patterns)]
 #![feature(std_misc)]
 #![feature(unboxed_closures)]
 #![deny(missing_copy_implementations)]


### PR DESCRIPTION
This fixes the build on `rustc 1.0.0-nightly (c89de2c56 2015-03-28) (built 2015-03-29)` for me.

  * `#![feature(path)]` is deprecated.
  * `Fn` inherits `FnMut` inherits `FnOnce`.
  * `#![feature(slicing_syntax)]`