### PR TITLE
Make examples build with rust beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: rust
+rust:
+  - nightly
+  - 1.0.0-beta
 sudo: false
 env:
   global:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-
 name = "noise"
 description = "Procedural noise generation library."
 homepage = "https://github.com/bjz/noise-rs"
@@ -10,7 +9,6 @@ keywords = ["math", "random"]
 authors = ["The Noise-rs Developers."]
 
 [lib]
-
 name = "noise"
 
 [[example]]
@@ -45,7 +43,7 @@ name = "benches"
 
 [dependencies]
 rand = "*"
-num = "0.1.21"
+num = "*"
 
 [dev-dependencies]
 image = "*"

--- a/examples/brownian.rs
+++ b/examples/brownian.rs
@@ -14,9 +14,6 @@
 
 //! An example of using fractal brownian motion on perlin noise
 
-#![feature(core)]
-#![feature(unboxed_closures)]
-
 extern crate noise;
 
 use noise::{Brownian2, Brownian3, Brownian4, perlin2, perlin3, perlin4, Seed, Point2};

--- a/examples/cell_manhattan.rs
+++ b/examples/cell_manhattan.rs
@@ -14,8 +14,6 @@
 
 //! An example of using cell range noise
 
-#![feature(core)]
-
 extern crate noise;
 
 use noise::{cell2_manhattan, cell3_manhattan, cell4_manhattan, Seed, Point2};

--- a/examples/cell_manhattan_inv.rs
+++ b/examples/cell_manhattan_inv.rs
@@ -14,8 +14,6 @@
 
 //! An example of using cell range noise
 
-#![feature(core)]
-
 extern crate noise;
 
 use noise::{cell2_manhattan_inv, cell3_manhattan_inv, cell4_manhattan_inv, Seed, Point2};

--- a/examples/cell_manhattan_value.rs
+++ b/examples/cell_manhattan_value.rs
@@ -14,8 +14,6 @@
 
 //! An example of using cell range noise
 
-#![feature(core)]
-
 extern crate noise;
 
 use noise::{cell2_manhattan_value, cell3_manhattan_value, cell4_manhattan_value, Seed, Point2};

--- a/examples/cell_range.rs
+++ b/examples/cell_range.rs
@@ -14,8 +14,6 @@
 
 //! An example of using cell range noise
 
-#![feature(core)]
-
 extern crate noise;
 
 use noise::{cell2_range, cell3_range, cell4_range, Seed, Point2};

--- a/examples/cell_range_inv.rs
+++ b/examples/cell_range_inv.rs
@@ -14,8 +14,6 @@
 
 //! An example of using cell range noise
 
-#![feature(core)]
-
 extern crate noise;
 
 use noise::{cell2_range_inv, cell3_range_inv, cell4_range_inv, Seed, Point2};

--- a/examples/cell_value.rs
+++ b/examples/cell_value.rs
@@ -14,8 +14,6 @@
 
 //! An example of using cell range noise
 
-#![feature(core)]
-
 extern crate noise;
 
 use noise::{cell2_value, cell3_value, cell4_value, Seed, Point2};

--- a/examples/debug/mod.rs
+++ b/examples/debug/mod.rs
@@ -15,13 +15,14 @@
 //! Useful things for debugging noise functions.
 
 extern crate image;
+extern crate num;
 
 use noise;
+use self::num::{Float, NumCast};
 use std::path::Path;
-use std::num::{self, Float, NumCast};
 
 fn cast<T: NumCast, R: NumCast>(val: T) -> R {
-    num::cast(val).unwrap()
+    num::traits::cast(val).unwrap()
 }
 
 fn clamp<F: Float>(val: F, min: F, max: F) -> F {

--- a/examples/open_simplex.rs
+++ b/examples/open_simplex.rs
@@ -14,8 +14,6 @@
 
 //! An example of using simplex noise
 
-#![feature(core)]
-
 extern crate noise;
 
 use noise::{open_simplex2, open_simplex3, Seed, Point2};

--- a/examples/perlin.rs
+++ b/examples/perlin.rs
@@ -14,8 +14,6 @@
 
 //! An example of using perlin noise
 
-#![feature(core)]
-
 extern crate noise;
 
 use noise::{perlin2, perlin3, perlin4, Seed, Point2};


### PR DESCRIPTION
Now that the image crate is updated all that's left is to use the num crate in the examples so they can build. This also makes `cargo test` work again.