### PR TITLE
Fix perlin scaling and other misc improvements

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -33,139 +33,139 @@ use test::{Bencher, black_box};
 #[bench]
 fn bench_perlin2(bencher: &mut Bencher) {
     let seed = Seed::new(0);
-    bencher.iter(|| perlin2(black_box(&seed), black_box(&[42.0f32, 37.0])));
+    bencher.iter(|| perlin2(black_box(&seed), black_box(&[42.0f64, 37.0])));
 }
 
 #[bench]
 fn bench_perlin3(bencher: &mut Bencher) {
     let seed = Seed::new(0);
-    bencher.iter(|| perlin3(black_box(&seed), black_box(&[42.0f32, 37.0, 26.0])));
+    bencher.iter(|| perlin3(black_box(&seed), black_box(&[42.0f64, 37.0, 26.0])));
 }
 
 #[bench]
 fn bench_perlin4(bencher: &mut Bencher) {
     let seed = Seed::new(0);
-    bencher.iter(|| perlin4(black_box(&seed), black_box(&[42.0f32, 37.0, 26.0, 128.0])));
+    bencher.iter(|| perlin4(black_box(&seed), black_box(&[42.0f64, 37.0, 26.0, 128.0])));
 }
 
 #[bench]
 fn bench_open_simplex2(bencher: &mut Bencher) {
     let seed = Seed::new(0);
-    bencher.iter(|| open_simplex2(black_box(&seed), black_box(&[42.0f32, 37.0])));
+    bencher.iter(|| open_simplex2(black_box(&seed), black_box(&[42.0f64, 37.0])));
 }
 
 #[bench]
 fn bench_open_simplex3(bencher: &mut Bencher) {
     let seed = Seed::new(0);
-    bencher.iter(|| open_simplex3(black_box(&seed), black_box(&[42.0f32, 37.0, 26.0])));
+    bencher.iter(|| open_simplex3(black_box(&seed), black_box(&[42.0f64, 37.0, 26.0])));
 }
 
 #[bench]
 fn bench_cell2_range(bencher: &mut Bencher) {
     let seed = Seed::new(0);
-    bencher.iter(|| cell2_range(black_box(&seed), black_box(&[42.0f32, 37.0])));
+    bencher.iter(|| cell2_range(black_box(&seed), black_box(&[42.0f64, 37.0])));
 }
 
 #[bench]
 fn bench_cell3_range(bencher: &mut Bencher) {
     let seed = Seed::new(0);
-    bencher.iter(|| cell3_range(black_box(&seed), black_box(&[42.0f32, 37.0, 26.0])));
+    bencher.iter(|| cell3_range(black_box(&seed), black_box(&[42.0f64, 37.0, 26.0])));
 }
 
 #[bench]
 fn bench_cell4_range(bencher: &mut Bencher) {
     let seed = Seed::new(0);
-    bencher.iter(|| cell4_range(black_box(&seed), black_box(&[42.0f32, 37.0, 26.0, 128.0])));
+    bencher.iter(|| cell4_range(black_box(&seed), black_box(&[42.0f64, 37.0, 26.0, 128.0])));
 }
 
 #[bench]
 fn bench_cell2_range_inv(bencher: &mut Bencher) {
     let seed = Seed::new(0);
-    bencher.iter(|| cell2_range_inv(black_box(&seed), black_box(&[42.0f32, 37.0])));
+    bencher.iter(|| cell2_range_inv(black_box(&seed), black_box(&[42.0f64, 37.0])));
 }
 
 #[bench]
 fn bench_cell3_range_inv(bencher: &mut Bencher) {
     let seed = Seed::new(0);
-    bencher.iter(|| cell3_range_inv(black_box(&seed), black_box(&[42.0f32, 37.0, 26.0])));
+    bencher.iter(|| cell3_range_inv(black_box(&seed), black_box(&[42.0f64, 37.0, 26.0])));
 }
 
 #[bench]
 fn bench_cell4_range_inv(bencher: &mut Bencher) {
     let seed = Seed::new(0);
-    bencher.iter(|| cell4_range_inv(black_box(&seed), black_box(&[42.0f32, 37.0, 26.0, 128.0])));
+    bencher.iter(|| cell4_range_inv(black_box(&seed), black_box(&[42.0f64, 37.0, 26.0, 128.0])));
 }
 
 #[bench]
 fn bench_cell2_value(bencher: &mut Bencher) {
     let seed = Seed::new(0);
-    bencher.iter(|| cell2_value(black_box(&seed), black_box(&[42.0f32, 37.0])));
+    bencher.iter(|| cell2_value(black_box(&seed), black_box(&[42.0f64, 37.0])));
 }
 
 #[bench]
 fn bench_cell3_value(bencher: &mut Bencher) {
     let seed = Seed::new(0);
-    bencher.iter(|| cell3_value(black_box(&seed), black_box(&[42.0f32, 37.0, 26.0])));
+    bencher.iter(|| cell3_value(black_box(&seed), black_box(&[42.0f64, 37.0, 26.0])));
 }
 
 #[bench]
 fn bench_cell4_value(bencher: &mut Bencher) {
     let seed = Seed::new(0);
-    bencher.iter(|| cell4_value(black_box(&seed), black_box(&[42.0f32, 37.0, 26.0, 128.0])));
+    bencher.iter(|| cell4_value(black_box(&seed), black_box(&[42.0f64, 37.0, 26.0, 128.0])));
 }
 
 #[bench]
 fn bench_cell2_manhattan(bencher: &mut Bencher) {
     let seed = Seed::new(0);
-    bencher.iter(|| cell2_manhattan(black_box(&seed), black_box(&[42.0f32, 37.0])));
+    bencher.iter(|| cell2_manhattan(black_box(&seed), black_box(&[42.0f64, 37.0])));
 }
 
 #[bench]
 fn bench_cell3_manhattan(bencher: &mut Bencher) {
     let seed = Seed::new(0);
-    bencher.iter(|| cell3_manhattan(black_box(&seed), black_box(&[42.0f32, 37.0, 26.0])));
+    bencher.iter(|| cell3_manhattan(black_box(&seed), black_box(&[42.0f64, 37.0, 26.0])));
 }
 
 #[bench]
 fn bench_cell4_manhattan(bencher: &mut Bencher) {
     let seed = Seed::new(0);
-    bencher.iter(|| cell4_manhattan(black_box(&seed), black_box(&[42.0f32, 37.0, 26.0, 128.0])));
+    bencher.iter(|| cell4_manhattan(black_box(&seed), black_box(&[42.0f64, 37.0, 26.0, 128.0])));
 }
 
 #[bench]
 fn bench_cell2_manhattan_inv(bencher: &mut Bencher) {
     let seed = Seed::new(0);
-    bencher.iter(|| cell2_manhattan_inv(black_box(&seed), black_box(&[42.0f32, 37.0])));
+    bencher.iter(|| cell2_manhattan_inv(black_box(&seed), black_box(&[42.0f64, 37.0])));
 }
 
 #[bench]
 fn bench_cell3_manhattan_inv(bencher: &mut Bencher) {
     let seed = Seed::new(0);
-    bencher.iter(|| cell3_manhattan_inv(black_box(&seed), black_box(&[42.0f32, 37.0, 26.0])));
+    bencher.iter(|| cell3_manhattan_inv(black_box(&seed), black_box(&[42.0f64, 37.0, 26.0])));
 }
 
 #[bench]
 fn bench_cell4_manhattan_inv(bencher: &mut Bencher) {
     let seed = Seed::new(0);
-    bencher.iter(|| cell4_manhattan_inv(black_box(&seed), black_box(&[42.0f32, 37.0, 26.0, 128.0])));
+    bencher.iter(|| cell4_manhattan_inv(black_box(&seed), black_box(&[42.0f64, 37.0, 26.0, 128.0])));
 }
 
 #[bench]
 fn bench_cell2_manhattan_value(bencher: &mut Bencher) {
     let seed = Seed::new(0);
-    bencher.iter(|| cell2_manhattan_value(black_box(&seed), black_box(&[42.0f32, 37.0])));
+    bencher.iter(|| cell2_manhattan_value(black_box(&seed), black_box(&[42.0f64, 37.0])));
 }
 
 #[bench]
 fn bench_cell3_manhattan_value(bencher: &mut Bencher) {
     let seed = Seed::new(0);
-    bencher.iter(|| cell3_manhattan_value(black_box(&seed), black_box(&[42.0f32, 37.0, 26.0])));
+    bencher.iter(|| cell3_manhattan_value(black_box(&seed), black_box(&[42.0f64, 37.0, 26.0])));
 }
 
 #[bench]
 fn bench_cell4_manhattan_value(bencher: &mut Bencher) {
     let seed = Seed::new(0);
-    bencher.iter(|| cell4_manhattan_value(black_box(&seed), black_box(&[42.0f32, 37.0, 26.0, 128.0])));
+    bencher.iter(|| cell4_manhattan_value(black_box(&seed), black_box(&[42.0f64, 37.0, 26.0, 128.0])));
 }
 
 #[bench]
@@ -174,7 +174,7 @@ fn bench_perlin2_64x64(bencher: &mut Bencher) {
     bencher.iter(|| {
         for y in 0..64 {
             for x in 0..64 {
-                black_box(perlin2(black_box(&seed), &[x as f32, y as f32]));
+                black_box(perlin2(black_box(&seed), &[x as f64, y as f64]));
             }
         }
     });
@@ -186,7 +186,7 @@ fn bench_perlin3_64x64(bencher: &mut Bencher) {
     bencher.iter(|| {
         for y in 0..64 {
             for x in 0..64 {
-                black_box(perlin3(black_box(&seed), &[x as f32, y as f32, x as f32]));
+                black_box(perlin3(black_box(&seed), &[x as f64, y as f64, x as f64]));
             }
         }
     });
@@ -198,7 +198,7 @@ fn bench_perlin4_64x64(bencher: &mut Bencher) {
     bencher.iter(|| {
         for y in 0..64 {
             for x in 0..64 {
-                black_box(perlin4(black_box(&seed), &[x as f32, y as f32, x as f32, y as f32]));
+                black_box(perlin4(black_box(&seed), &[x as f64, y as f64, x as f64, y as f64]));
             }
         }
     });
@@ -210,7 +210,7 @@ fn bench_open_simplex2_64x64(bencher: &mut Bencher) {
     bencher.iter(|| {
         for y in 0..64 {
             for x in 0..64 {
-                black_box(open_simplex2(black_box(&seed), &[x as f32, y as f32]));
+                black_box(open_simplex2(black_box(&seed), &[x as f64, y as f64]));
             }
         }
     });
@@ -222,7 +222,7 @@ fn bench_open_simplex3_64x64(bencher: &mut Bencher) {
     bencher.iter(|| {
         for y in 0..64 {
             for x in 0..64 {
-                black_box(open_simplex3(black_box(&seed), &[x as f32, y as f32, x as f32]));
+                black_box(open_simplex3(black_box(&seed), &[x as f64, y as f64, x as f64]));
             }
         }
     });
@@ -234,7 +234,7 @@ fn bench_cell2_range_64x64(bencher: &mut Bencher) {
     bencher.iter(|| {
         for y in 0..64 {
             for x in 0..64 {
-                black_box(cell2_range(black_box(&seed), &[x as f32, y as f32]));
+                black_box(cell2_range(black_box(&seed), &[x as f64, y as f64]));
             }
         }
     });
@@ -246,7 +246,7 @@ fn bench_cell3_range_64x64(bencher: &mut Bencher) {
     bencher.iter(|| {
         for y in 0..64 {
             for x in 0..64 {
-                black_box(cell3_range(black_box(&seed), &[x as f32, y as f32, x as f32]));
+                black_box(cell3_range(black_box(&seed), &[x as f64, y as f64, x as f64]));
             }
         }
     });
@@ -258,7 +258,7 @@ fn bench_cell4_range_64x64(bencher: &mut Bencher) {
     bencher.iter(|| {
         for y in 0..64 {
             for x in 0..64 {
-                black_box(cell4_range(black_box(&seed), &[x as f32, y as f32, x as f32, y as f32]));
+                black_box(cell4_range(black_box(&seed), &[x as f64, y as f64, x as f64, y as f64]));
             }
         }
     });
@@ -270,7 +270,7 @@ fn bench_cell2_range_inv_64x64(bencher: &mut Bencher) {
     bencher.iter(|| {
         for y in 0..64 {
             for x in 0..64 {
-                black_box(cell2_range_inv(black_box(&seed), &[x as f32, y as f32]));
+                black_box(cell2_range_inv(black_box(&seed), &[x as f64, y as f64]));
             }
         }
     });
@@ -282,7 +282,7 @@ fn bench_cell3_range_inv_64x64(bencher: &mut Bencher) {
     bencher.iter(|| {
         for y in 0..64 {
             for x in 0..64 {
-                black_box(cell3_range_inv(black_box(&seed), &[x as f32, y as f32, x as f32]));
+                black_box(cell3_range_inv(black_box(&seed), &[x as f64, y as f64, x as f64]));
             }
         }
     });
@@ -294,7 +294,7 @@ fn bench_cell4_range_inv_64x64(bencher: &mut Bencher) {
     bencher.iter(|| {
         for y in 0..64 {
             for x in 0..64 {
-                black_box(cell4_range_inv(black_box(&seed), &[x as f32, y as f32, x as f32, y as f32]));
+                black_box(cell4_range_inv(black_box(&seed), &[x as f64, y as f64, x as f64, y as f64]));
             }
         }
     });
@@ -306,7 +306,7 @@ fn bench_cell2_value_64x64(bencher: &mut Bencher) {
     bencher.iter(|| {
         for y in 0..64 {
             for x in 0..64 {
-                black_box(cell2_value(black_box(&seed), &[x as f32, y as f32]));
+                black_box(cell2_value(black_box(&seed), &[x as f64, y as f64]));
             }
         }
     });
@@ -318,7 +318,7 @@ fn bench_cell3_value_64x64(bencher: &mut Bencher) {
     bencher.iter(|| {
         for y in 0..64 {
             for x in 0..64 {
-                black_box(cell3_value(black_box(&seed), &[x as f32, y as f32, x as f32]));
+                black_box(cell3_value(black_box(&seed), &[x as f64, y as f64, x as f64]));
             }
         }
     });
@@ -330,7 +330,7 @@ fn bench_cell4_value_64x64(bencher: &mut Bencher) {
     bencher.iter(|| {
         for y in 0..64 {
             for x in 0..64 {
-                black_box(cell4_value(black_box(&seed), &[x as f32, y as f32, x as f32, y as f32]));
+                black_box(cell4_value(black_box(&seed), &[x as f64, y as f64, x as f64, y as f64]));
             }
         }
     });
@@ -342,7 +342,7 @@ fn bench_cell2_manhattan_64x64(bencher: &mut Bencher) {
     bencher.iter(|| {
         for y in 0..64 {
             for x in 0..64 {
-                black_box(cell2_manhattan(black_box(&seed), &[x as f32, y as f32]));
+                black_box(cell2_manhattan(black_box(&seed), &[x as f64, y as f64]));
             }
         }
     });
@@ -354,7 +354,7 @@ fn bench_cell3_manhattan_64x64(bencher: &mut Bencher) {
     bencher.iter(|| {
         for y in 0..64 {
             for x in 0..64 {
-                black_box(cell3_manhattan(black_box(&seed), &[x as f32, y as f32, x as f32]));
+                black_box(cell3_manhattan(black_box(&seed), &[x as f64, y as f64, x as f64]));
             }
         }
     });
@@ -366,7 +366,7 @@ fn bench_cell4_manhattan_64x64(bencher: &mut Bencher) {
     bencher.iter(|| {
         for y in 0..64 {
             for x in 0..64 {
-                black_box(cell4_manhattan(black_box(&seed), &[x as f32, y as f32, x as f32, y as f32]));
+                black_box(cell4_manhattan(black_box(&seed), &[x as f64, y as f64, x as f64, y as f64]));
             }
         }
     });
@@ -378,7 +378,7 @@ fn bench_cell2_manhattan_inv_64x64(bencher: &mut Bencher) {
     bencher.iter(|| {
         for y in 0..64 {
             for x in 0..64 {
-                black_box(cell2_manhattan_inv(black_box(&seed), &[x as f32, y as f32]));
+                black_box(cell2_manhattan_inv(black_box(&seed), &[x as f64, y as f64]));
             }
         }
     });
@@ -390,7 +390,7 @@ fn bench_cell3_manhattan_inv_64x64(bencher: &mut Bencher) {
     bencher.iter(|| {
         for y in 0..64 {
             for x in 0..64 {
-                black_box(cell3_manhattan_inv(black_box(&seed), &[x as f32, y as f32, x as f32]));
+                black_box(cell3_manhattan_inv(black_box(&seed), &[x as f64, y as f64, x as f64]));
             }
         }
     });
@@ -402,7 +402,7 @@ fn bench_cell4_manhattan_inv_64x64(bencher: &mut Bencher) {
     bencher.iter(|| {
         for y in 0..64 {
             for x in 0..64 {
-                black_box(cell4_manhattan_inv(black_box(&seed), &[x as f32, y as f32, x as f32, y as f32]));
+                black_box(cell4_manhattan_inv(black_box(&seed), &[x as f64, y as f64, x as f64, y as f64]));
             }
         }
     });
@@ -414,7 +414,7 @@ fn bench_cell2_manhattan_value_64x64(bencher: &mut Bencher) {
     bencher.iter(|| {
         for y in 0..64 {
             for x in 0..64 {
-                black_box(cell2_manhattan_value(black_box(&seed), &[x as f32, y as f32]));
+                black_box(cell2_manhattan_value(black_box(&seed), &[x as f64, y as f64]));
             }
         }
     });
@@ -426,7 +426,7 @@ fn bench_cell3_manhattan_value_64x64(bencher: &mut Bencher) {
     bencher.iter(|| {
         for y in 0..64 {
             for x in 0..64 {
-                black_box(cell3_manhattan_value(black_box(&seed), &[x as f32, y as f32, x as f32]));
+                black_box(cell3_manhattan_value(black_box(&seed), &[x as f64, y as f64, x as f64]));
             }
         }
     });
@@ -438,7 +438,7 @@ fn bench_cell4_manhattan_value_64x64(bencher: &mut Bencher) {
     bencher.iter(|| {
         for y in 0..64 {
             for x in 0..64 {
-                black_box(cell4_manhattan_value(black_box(&seed), &[x as f32, y as f32, x as f32, y as f32]));
+                black_box(cell4_manhattan_value(black_box(&seed), &[x as f64, y as f64, x as f64, y as f64]));
             }
         }
     });

--- a/examples/brownian.rs
+++ b/examples/brownian.rs
@@ -28,13 +28,13 @@ fn main() {
 }
 
 fn brownian2_for_image(seed: &Seed, point: &Point2<f64>) -> f64 {
-    Brownian2::new(perlin2, 4).wavelength(16.0).apply(seed, point)
+    Brownian2::new(perlin2, 8).wavelength(1024.0).apply(seed, point)
 }
 
 fn brownian3_for_image(seed: &Seed, point: &Point2<f64>) -> f64 {
-    Brownian3::new(perlin3, 4).wavelength(16.0).apply(seed, &[point[0], point[1], point[0]])
+    Brownian3::new(perlin3, 8).wavelength(1024.0).apply(seed, &[point[0], point[1], point[0] / 2.0])
 }
 
 fn brownian4_for_image(seed: &Seed, point: &Point2<f64>) -> f64 {
-    Brownian4::new(perlin4, 4).wavelength(16.0).apply(seed, &[point[0], point[1], point[0], point[1]])
+    Brownian4::new(perlin4, 8).wavelength(1024.0).apply(seed, &[point[0], point[1], point[0] / 2.0, point[1] / 2.0])
 }

--- a/examples/brownian.rs
+++ b/examples/brownian.rs
@@ -27,14 +27,14 @@ fn main() {
     println!("\nGenerated brownian2.png, brownian3.png and brownian4.png");
 }
 
-fn brownian2_for_image(seed: &Seed, point: &Point2<f32>) -> f32 {
+fn brownian2_for_image(seed: &Seed, point: &Point2<f64>) -> f64 {
     Brownian2::new(perlin2, 4).wavelength(16.0).apply(seed, point)
 }
 
-fn brownian3_for_image(seed: &Seed, point: &Point2<f32>) -> f32 {
-    Brownian3::new(perlin3, 4).wavelength(16.0).apply(seed, &[point[0], point[1], 0.0])
+fn brownian3_for_image(seed: &Seed, point: &Point2<f64>) -> f64 {
+    Brownian3::new(perlin3, 4).wavelength(16.0).apply(seed, &[point[0], point[1], point[0]])
 }
 
-fn brownian4_for_image(seed: &Seed, point: &Point2<f32>) -> f32 {
-    Brownian4::new(perlin4, 4).wavelength(16.0).apply(seed, &[point[0], point[1], 0.0, 0.0])
+fn brownian4_for_image(seed: &Seed, point: &Point2<f64>) -> f64 {
+    Brownian4::new(perlin4, 4).wavelength(16.0).apply(seed, &[point[0], point[1], point[0], point[1]])
 }

--- a/examples/cell_manhattan.rs
+++ b/examples/cell_manhattan.rs
@@ -21,20 +21,20 @@ use noise::{cell2_manhattan, cell3_manhattan, cell4_manhattan, Seed, Point2};
 mod debug;
 
 fn main() {
-    debug::render_png("cell2_manhattan.png", &Seed::new(0), 256, 256, scaled_cell2_manhattan);
-    debug::render_png("cell3_manhattan.png", &Seed::new(0), 256, 256, scaled_cell3_manhattan);
-    debug::render_png("cell4_manhattan.png", &Seed::new(0), 256, 256, scaled_cell4_manhattan);
+    debug::render_png("cell2_manhattan.png", &Seed::new(0), 1024, 1024, scaled_cell2_manhattan);
+    debug::render_png("cell3_manhattan.png", &Seed::new(0), 1024, 1024, scaled_cell3_manhattan);
+    debug::render_png("cell4_manhattan.png", &Seed::new(0), 1024, 1024, scaled_cell4_manhattan);
     println!("\nGenerated cell2_manhattan.png, cell3_manhattan.png and cell4_manhattan.png");
 }
 
-fn scaled_cell2_manhattan(seed: &Seed, point: &Point2<f32>) -> f32 {
-    cell2_manhattan(seed, &[point[0] / 32.0f32, point[1] / 32.00]) * 2.0 - 1.0
+fn scaled_cell2_manhattan(seed: &Seed, point: &Point2<f64>) -> f64 {
+    cell2_manhattan(seed, &[point[0] / 16.0, point[1] / 16.0]) * 2.0 - 1.0
 }
 
-fn scaled_cell3_manhattan(seed: &Seed, point: &Point2<f32>) -> f32 {
-    cell3_manhattan(seed, &[point[0] / 32.0f32, point[1] / 32.00, 0.0]) * 2.0 - 1.0
+fn scaled_cell3_manhattan(seed: &Seed, point: &Point2<f64>) -> f64 {
+    cell3_manhattan(seed, &[point[0] / 16.0, point[1] / 16.0, point[0] / 32.0]) * 2.0 - 1.0
 }
 
-fn scaled_cell4_manhattan(seed: &Seed, point: &Point2<f32>) -> f32 {
-    cell4_manhattan(seed, &[point[0] / 32.0f32, point[1] / 32.00, 0.0, 0.0]) * 2.0 - 1.0
+fn scaled_cell4_manhattan(seed: &Seed, point: &Point2<f64>) -> f64 {
+    cell4_manhattan(seed, &[point[0] / 16.0, point[1] / 16.0, point[0] / 32.0, point[1] / 32.0]) * 2.0 - 1.0
 }

--- a/examples/cell_manhattan_inv.rs
+++ b/examples/cell_manhattan_inv.rs
@@ -21,20 +21,20 @@ use noise::{cell2_manhattan_inv, cell3_manhattan_inv, cell4_manhattan_inv, Seed,
 mod debug;
 
 fn main() {
-    debug::render_png("cell2_manhattan_inv.png", &Seed::new(0), 256, 256, scaled_cell2_manhattan_inv);
-    debug::render_png("cell3_manhattan_inv.png", &Seed::new(0), 256, 256, scaled_cell3_manhattan_inv);
-    debug::render_png("cell4_manhattan_inv.png", &Seed::new(0), 256, 256, scaled_cell4_manhattan_inv);
+    debug::render_png("cell2_manhattan_inv.png", &Seed::new(0), 1024, 1024, scaled_cell2_manhattan_inv);
+    debug::render_png("cell3_manhattan_inv.png", &Seed::new(0), 1024, 1024, scaled_cell3_manhattan_inv);
+    debug::render_png("cell4_manhattan_inv.png", &Seed::new(0), 1024, 1024, scaled_cell4_manhattan_inv);
     println!("\nGenerated cell2_manhattan_inv.png, cell3_manhattan_inv.png and cell4_manhattan_inv.png");
 }
 
-fn scaled_cell2_manhattan_inv(seed: &Seed, point: &Point2<f32>) -> f32 {
-    cell2_manhattan_inv(seed, &[point[0] / 32.0f32, point[1] / 32.00]) * 2.0 - 1.0
+fn scaled_cell2_manhattan_inv(seed: &Seed, point: &Point2<f64>) -> f64 {
+    cell2_manhattan_inv(seed, &[point[0] / 16.0, point[1] / 16.0]) * 2.0 - 1.0
 }
 
-fn scaled_cell3_manhattan_inv(seed: &Seed, point: &Point2<f32>) -> f32 {
-    cell3_manhattan_inv(seed, &[point[0] / 32.0f32, point[1] / 32.00, 0.0]) * 2.0 - 1.0
+fn scaled_cell3_manhattan_inv(seed: &Seed, point: &Point2<f64>) -> f64 {
+    cell3_manhattan_inv(seed, &[point[0] / 16.0, point[1] / 16.0, point[0] / 16.0]) * 2.0 - 1.0
 }
 
-fn scaled_cell4_manhattan_inv(seed: &Seed, point: &Point2<f32>) -> f32 {
-    cell4_manhattan_inv(seed, &[point[0] / 32.0f32, point[1] / 32.00, 0.0, 0.0]) * 2.0 - 1.0
+fn scaled_cell4_manhattan_inv(seed: &Seed, point: &Point2<f64>) -> f64 {
+    cell4_manhattan_inv(seed, &[point[0] / 16.0, point[1] / 16.0, point[0] / 16.0, point[1] / 16.0]) * 2.0 - 1.0
 }

--- a/examples/cell_manhattan_value.rs
+++ b/examples/cell_manhattan_value.rs
@@ -21,20 +21,20 @@ use noise::{cell2_manhattan_value, cell3_manhattan_value, cell4_manhattan_value,
 mod debug;
 
 fn main() {
-    debug::render_png("cell2_manhattan_value.png", &Seed::new(0), 256, 256, scaled_cell2_manhattan_value);
-    debug::render_png("cell3_manhattan_value.png", &Seed::new(0), 256, 256, scaled_cell3_manhattan_value);
-    debug::render_png("cell4_manhattan_value.png", &Seed::new(0), 256, 256, scaled_cell4_manhattan_value);
+    debug::render_png("cell2_manhattan_value.png", &Seed::new(0), 1024, 1024, scaled_cell2_manhattan_value);
+    debug::render_png("cell3_manhattan_value.png", &Seed::new(0), 1024, 1024, scaled_cell3_manhattan_value);
+    debug::render_png("cell4_manhattan_value.png", &Seed::new(0), 1024, 1024, scaled_cell4_manhattan_value);
     println!("\nGenerated cell2_manhattan_value.png, cell3_manhattan_value.png and cell4_manhattan_value.png");
 }
 
-fn scaled_cell2_manhattan_value(seed: &Seed, point: &Point2<f32>) -> f32 {
-    cell2_manhattan_value(seed, &[point[0] / 32.0f32, point[1] / 32.00]) * 2.0 - 1.0
+fn scaled_cell2_manhattan_value(seed: &Seed, point: &Point2<f64>) -> f64 {
+    cell2_manhattan_value(seed, &[point[0] / 16.0, point[1] / 16.0]) * 2.0 - 1.0
 }
 
-fn scaled_cell3_manhattan_value(seed: &Seed, point: &Point2<f32>) -> f32 {
-    cell3_manhattan_value(seed, &[point[0] / 32.0f32, point[1] / 32.00, 0.0]) * 2.0 - 1.0
+fn scaled_cell3_manhattan_value(seed: &Seed, point: &Point2<f64>) -> f64 {
+    cell3_manhattan_value(seed, &[point[0] / 16.0, point[1] / 16.0, point[0] / 32.0]) * 2.0 - 1.0
 }
 
-fn scaled_cell4_manhattan_value(seed: &Seed, point: &Point2<f32>) -> f32 {
-    cell4_manhattan_value(seed, &[point[0] / 32.0f32, point[1] / 32.00, 0.0, 0.0]) * 2.0 - 1.0
+fn scaled_cell4_manhattan_value(seed: &Seed, point: &Point2<f64>) -> f64 {
+    cell4_manhattan_value(seed, &[point[0] / 16.0, point[1] / 16.0, point[0] / 32.0, point[1] / 32.0]) * 2.0 - 1.0
 }

--- a/examples/cell_range.rs
+++ b/examples/cell_range.rs
@@ -21,20 +21,20 @@ use noise::{cell2_range, cell3_range, cell4_range, Seed, Point2};
 mod debug;
 
 fn main() {
-    debug::render_png("cell2_range.png", &Seed::new(0), 256, 256, scaled_cell2_range);
-    debug::render_png("cell3_range.png", &Seed::new(0), 256, 256, scaled_cell3_range);
-    debug::render_png("cell4_range.png", &Seed::new(0), 256, 256, scaled_cell4_range);
+    debug::render_png("cell2_range.png", &Seed::new(0), 1024, 1024, scaled_cell2_range);
+    debug::render_png("cell3_range.png", &Seed::new(0), 1024, 1024, scaled_cell3_range);
+    debug::render_png("cell4_range.png", &Seed::new(0), 1024, 1024, scaled_cell4_range);
     println!("\nGenerated cell2_range.png, cell3_range.png and cell4_range.png");
 }
 
-fn scaled_cell2_range(seed: &Seed, point: &Point2<f32>) -> f32 {
-    cell2_range(seed, &[point[0] / 32.0f32, point[1] / 32.00]) * 2.0 - 1.0
+fn scaled_cell2_range(seed: &Seed, point: &Point2<f64>) -> f64 {
+    cell2_range(seed, &[point[0] / 16.0, point[1] / 16.0]) * 2.0 - 1.0
 }
 
-fn scaled_cell3_range(seed: &Seed, point: &Point2<f32>) -> f32 {
-    cell3_range(seed, &[point[0] / 32.0f32, point[1] / 32.00, 0.0]) * 2.0 - 1.0
+fn scaled_cell3_range(seed: &Seed, point: &Point2<f64>) -> f64 {
+    cell3_range(seed, &[point[0] / 16.0, point[1] / 16.0, point[0] / 32.0]) * 2.0 - 1.0
 }
 
-fn scaled_cell4_range(seed: &Seed, point: &Point2<f32>) -> f32 {
-    cell4_range(seed, &[point[0] / 32.0f32, point[1] / 32.00, 0.0, 0.0]) * 2.0 - 1.0
+fn scaled_cell4_range(seed: &Seed, point: &Point2<f64>) -> f64 {
+    cell4_range(seed, &[point[0] / 16.0, point[1] / 16.0, point[0] / 32.0, point[1] / 32.0]) * 2.0 - 1.0
 }

--- a/examples/cell_range_inv.rs
+++ b/examples/cell_range_inv.rs
@@ -21,20 +21,20 @@ use noise::{cell2_range_inv, cell3_range_inv, cell4_range_inv, Seed, Point2};
 mod debug;
 
 fn main() {
-    debug::render_png("cell2_range_inv.png", &Seed::new(0), 256, 256, scaled_cell2_range_inv);
-    debug::render_png("cell3_range_inv.png", &Seed::new(0), 256, 256, scaled_cell3_range_inv);
-    debug::render_png("cell4_range_inv.png", &Seed::new(0), 256, 256, scaled_cell4_range_inv);
+    debug::render_png("cell2_range_inv.png", &Seed::new(0), 1024, 1024, scaled_cell2_range_inv);
+    debug::render_png("cell3_range_inv.png", &Seed::new(0), 1024, 1024, scaled_cell3_range_inv);
+    debug::render_png("cell4_range_inv.png", &Seed::new(0), 1024, 1024, scaled_cell4_range_inv);
     println!("\nGenerated cell2_range_inv.png, cell3_range_inv.png and cell4_range_inv.png");
 }
 
-fn scaled_cell2_range_inv(seed: &Seed, point: &Point2<f32>) -> f32 {
-    cell2_range_inv(seed, &[point[0] / 32.0f32, point[1] / 32.00]) * 2.0 - 1.0
+fn scaled_cell2_range_inv(seed: &Seed, point: &Point2<f64>) -> f64 {
+    cell2_range_inv(seed, &[point[0] / 16.0, point[1] / 16.0]) * 2.0 - 1.0
 }
 
-fn scaled_cell3_range_inv(seed: &Seed, point: &Point2<f32>) -> f32 {
-    cell3_range_inv(seed, &[point[0] / 32.0f32, point[1] / 32.00, 0.0]) * 2.0 - 1.0
+fn scaled_cell3_range_inv(seed: &Seed, point: &Point2<f64>) -> f64 {
+    cell3_range_inv(seed, &[point[0] / 16.0, point[1] / 16.0, point[0] / 32.0]) * 2.0 - 1.0
 }
 
-fn scaled_cell4_range_inv(seed: &Seed, point: &Point2<f32>) -> f32 {
-    cell4_range_inv(seed, &[point[0] / 32.0f32, point[1] / 32.00, 0.0, 0.0]) * 2.0 - 1.0
+fn scaled_cell4_range_inv(seed: &Seed, point: &Point2<f64>) -> f64 {
+    cell4_range_inv(seed, &[point[0] / 16.0, point[1] / 16.0, point[0] / 32.0, point[1] / 32.0]) * 2.0 - 1.0
 }

--- a/examples/cell_value.rs
+++ b/examples/cell_value.rs
@@ -21,20 +21,20 @@ use noise::{cell2_value, cell3_value, cell4_value, Seed, Point2};
 mod debug;
 
 fn main() {
-    debug::render_png("cell2_value.png", &Seed::new(0), 256, 256, scaled_cell2_value);
-    debug::render_png("cell3_value.png", &Seed::new(0), 256, 256, scaled_cell3_value);
-    debug::render_png("cell4_value.png", &Seed::new(0), 256, 256, scaled_cell4_value);
+    debug::render_png("cell2_value.png", &Seed::new(0), 1024, 1024, scaled_cell2_value);
+    debug::render_png("cell3_value.png", &Seed::new(0), 1024, 1024, scaled_cell3_value);
+    debug::render_png("cell4_value.png", &Seed::new(0), 1024, 1024, scaled_cell4_value);
     println!("\nGenerated cell2_value.png, cell3_value.png and cell4_value.png");
 }
 
-fn scaled_cell2_value(seed: &Seed, point: &Point2<f32>) -> f32 {
-    cell2_value(seed, &[point[0] / 32.0f32, point[1] / 32.00]) * 2.0 - 1.0
+fn scaled_cell2_value(seed: &Seed, point: &Point2<f64>) -> f64 {
+    cell2_value(seed, &[point[0] / 16.0, point[1] / 16.0]) * 2.0 - 1.0
 }
 
-fn scaled_cell3_value(seed: &Seed, point: &Point2<f32>) -> f32 {
-    cell3_value(seed, &[point[0] / 32.0f32, point[1] / 32.00, 0.0]) * 2.0 - 1.0
+fn scaled_cell3_value(seed: &Seed, point: &Point2<f64>) -> f64 {
+    cell3_value(seed, &[point[0] / 16.0, point[1] / 16.0, point[0] / 32.0]) * 2.0 - 1.0
 }
 
-fn scaled_cell4_value(seed: &Seed, point: &Point2<f32>) -> f32 {
-    cell4_value(seed, &[point[0] / 32.0f32, point[1] / 32.00, 0.0, 0.0]) * 2.0 - 1.0
+fn scaled_cell4_value(seed: &Seed, point: &Point2<f64>) -> f64 {
+    cell4_value(seed, &[point[0] / 16.0, point[1] / 16.0, point[0] / 32.0, point[1] / 32.0]) * 2.0 - 1.0
 }

--- a/examples/debug/mod.rs
+++ b/examples/debug/mod.rs
@@ -39,9 +39,9 @@ pub fn render_png<T, F>(filename: &str, seed: &noise::Seed, width: u32, height: 
 {
     let mut pixels = Vec::with_capacity((width * height) as usize);
 
-    for y in (0..height) {
-        for x in (0..width) {
-            let value: f32 = cast(func(seed, &[cast::<_,T>(x) - cast::<_,T>(width/2), cast::<_,T>(y) - cast::<_,T>(height/2)]));
+    for y in 0..height {
+        for x in 0..width {
+            let value: f64 = cast(func(seed, &[cast::<_,T>(x) - cast::<_,T>(width/2), cast::<_,T>(y) - cast::<_,T>(height/2)]));
             pixels.push(cast(clamp(value * 0.5 + 0.5, 0.0, 1.0) * 255.0));
         }
     }

--- a/examples/open_simplex.rs
+++ b/examples/open_simplex.rs
@@ -26,10 +26,10 @@ fn main() {
     println!("\nGenerated open_simplex2.png and open_simplex3.png");
 }
 
-fn scaled_open_simplex2(seed: &Seed, point: &Point2<f32>) -> f32 {
+fn scaled_open_simplex2(seed: &Seed, point: &Point2<f64>) -> f64 {
     open_simplex2(seed, &[point[0] / 16.0, point[1] / 16.0])
 }
 
-fn scaled_open_simplex3(seed: &Seed, point: &Point2<f32>) -> f32 {
-    open_simplex3(seed, &[point[0] / 16.0, point[1] / 16.0, 0.0])
+fn scaled_open_simplex3(seed: &Seed, point: &Point2<f64>) -> f64 {
+    open_simplex3(seed, &[point[0] / 16.0, point[1] / 16.0, point[0] / 32.0])
 }

--- a/examples/perlin.rs
+++ b/examples/perlin.rs
@@ -27,14 +27,14 @@ fn main() {
     println!("\nGenerated perlin2.png, perlin3.png and perlin4.png");
 }
 
-fn scaled_perlin2(seed: &Seed, point: &Point2<f32>) -> f32 {
+fn scaled_perlin2(seed: &Seed, point: &Point2<f64>) -> f64 {
     perlin2(seed, &[point[0] / 16.0, point[1] / 16.0])
 }
 
-fn scaled_perlin3(seed: &Seed, point: &Point2<f32>) -> f32 {
-    perlin3(seed, &[point[0] / 16.0, point[1] / 16.0, 0.0])
+fn scaled_perlin3(seed: &Seed, point: &Point2<f64>) -> f64 {
+    perlin3(seed, &[point[0] / 16.0, point[1] / 16.0, point[0] / 32.0])
 }
 
-fn scaled_perlin4(seed: &Seed, point: &Point2<f32>) -> f32 {
-    perlin4(seed, &[point[0] / 16.0, point[1] / 16.0, 0.0, 0.0])
+fn scaled_perlin4(seed: &Seed, point: &Point2<f64>) -> f64 {
+    perlin4(seed, &[point[0] / 16.0, point[1] / 16.0, point[0] / 32.0, point[1] / 32.0])
 }

--- a/src/brownian.rs
+++ b/src/brownian.rs
@@ -207,15 +207,17 @@ macro_rules! impl_brownian {
             pub fn apply(&self, seed: &Seed, point: &$Point<T>) -> T {
                 let mut frequency: T = self.frequency;
                 let mut amplitude: T = math::cast(1);
+                let mut total_amplitude = T::zero();
                 let mut result: T = math::cast(0);
                 let point = *point;
                 for _ in 0..self.octaves {
                     let scaled_point = $mapn(point, |v| v * frequency);
                     result = result + ((self.function)(seed, &scaled_point) * amplitude);
+                    total_amplitude = total_amplitude + amplitude;
                     amplitude = amplitude * self.persistence;
                     frequency = frequency * self.lacunarity;
                 }
-                result
+                result / total_amplitude
             }
         }
     }

--- a/src/gradient.rs
+++ b/src/gradient.rs
@@ -17,60 +17,143 @@ use num::Float;
 use math;
 
 #[inline(always)]
-fn gradient<T: Float>(index: usize) -> math::Point4<T> {
-    let one = T::one();
+pub fn get2<T: Float>(index: usize) -> math::Vector2<T> {
     let zero = T::zero();
+    let one = T::one();
+    // Vectors are combinations of -1, 0, and 1, precompute the normalized element
+    let norm = math::cast(0.7071067811865475);
+
+    match index % 8 {
+        0 => [ one,   zero],
+        1 => [-one,   zero],
+        2 => [ zero,  one],
+        3 => [ zero, -one],
+        4 => [ norm,  norm],
+        5 => [-norm,  norm],
+        6 => [ norm, -norm],
+        7 => [-norm, -norm],
+        _ => panic!("Attempt to access gradient {} of 8", index % 8),
+    }
+}
+
+#[inline(always)]
+pub fn get3<T: Float>(index: usize) -> math::Vector3<T> {
+    let zero = T::zero();
+    // Vectors are combinations of -1, 0, and 1, precompute the normalized elements
+    let norm = math::cast(0.7071067811865475);
+    let norm2 = math::cast(0.5773502691896258);
 
     match index % 32 {
-        0  => [ zero,  one,   one,   one],
-        1  => [ zero,  one,   one,  -one],
-        2  => [ zero,  one,  -one,   one],
-        3  => [ zero,  one,  -one,  -one],
-        4  => [ zero, -one,   one,   one],
-        5  => [ zero, -one,   one,  -one],
-        6  => [ zero, -one,  -one,   one],
-        7  => [ zero, -one,  -one,  -one],
-        8  => [ one,   zero,  one,   one],
-        9  => [ one,   zero,  one,  -one],
-        10 => [ one,   zero, -one,   one],
-        11 => [ one,   zero, -one,  -one],
-        12 => [-one,   zero,  one,   one],
-        13 => [-one,   zero,  one,  -one],
-        14 => [-one,   zero, -one,   one],
-        15 => [-one,   zero, -one,  -one],
-        16 => [ one,   one,   zero,  one],
-        17 => [ one,   one,   zero, -one],
-        18 => [ one,  -one,   zero,  one],
-        19 => [ one,  -one,   zero, -one],
-        20 => [-one,   one,   zero,  one],
-        21 => [-one,   one,   zero, -one],
-        22 => [-one,  -one,   zero,  one],
-        23 => [-one,  -one,   zero, -one],
-        24 => [ one,   one,   one,   zero],
-        25 => [ one,   one,  -one,   zero],
-        26 => [ one,  -one,   one,   zero],
-        27 => [ one,  -one,  -one,   zero],
-        28 => [-one,   one,   one,   zero],
-        29 => [-one,   one,  -one,   zero],
-        30 => [-one,  -one,   one,   zero],
-        31 => [-one,  -one,  -one,   zero],
+        // 12 edges repeated twice then 8 corners
+        0  => [ norm,  norm,  zero],
+        1  => [-norm,  norm,  zero],
+        2  => [ norm, -norm,  zero],
+        3  => [-norm, -norm,  zero],
+        4  => [ norm,  zero,  norm],
+        5  => [-norm,  zero,  norm],
+        6  => [ norm,  zero, -norm],
+        7  => [-norm,  zero, -norm],
+        8  => [ zero,  norm,  norm],
+        9  => [ zero, -norm,  norm],
+        10 => [ zero,  norm, -norm],
+        11 => [ zero, -norm, -norm],
+        12 => [ norm,  norm,  zero],
+        13 => [-norm,  norm,  zero],
+        14 => [ norm, -norm,  zero],
+        15 => [-norm, -norm,  zero],
+        16 => [ norm,  zero,  norm],
+        17 => [-norm,  zero,  norm],
+        18 => [ norm,  zero, -norm],
+        19 => [-norm,  zero, -norm],
+        20 => [ zero,  norm,  norm],
+        21 => [ zero, -norm,  norm],
+        22 => [ zero,  norm, -norm],
+        23 => [ zero, -norm, -norm],
+        24 => [ norm2,  norm2,  norm2],
+        25 => [-norm2,  norm2,  norm2],
+        26 => [ norm2, -norm2,  norm2],
+        27 => [-norm2, -norm2,  norm2],
+        28 => [ norm2,  norm2, -norm2],
+        29 => [-norm2,  norm2, -norm2],
+        30 => [ norm2, -norm2, -norm2],
+        31 => [-norm2, -norm2, -norm2],
         _ => panic!("Attempt to access gradient {} of 32", index % 32),
     }
 }
 
 #[inline(always)]
-pub fn get2<T: Float>(index: usize) -> math::Point2<T> {
-    let value = gradient(index);
-    [value[0], value[1]]
-}
+pub fn get4<T: Float>(index: usize) -> math::Vector4<T> {
+    let zero = T::zero();
+    // Vectors are combinations of -1, 0, and 1, precompute the normalized elements
+    let norm = math::cast(0.5773502691896258);
+    let norm2 = math::cast(0.5);
 
-#[inline(always)]
-pub fn get3<T: Float>(index: usize) -> math::Point3<T> {
-    let value = gradient(index);
-    [value[0], value[1], value[2]]
-}
-
-#[inline(always)]
-pub fn get4<T: Float>(index: usize) -> math::Point4<T> {
-    gradient(index)
+    match index % 64 {
+        // 32 edges then 16 corners repeated twice
+        0  => [ zero,  norm,  norm,  norm],
+        1  => [ zero,  norm,  norm, -norm],
+        2  => [ zero,  norm, -norm,  norm],
+        3  => [ zero,  norm, -norm, -norm],
+        4  => [ zero, -norm,  norm,  norm],
+        5  => [ zero, -norm,  norm, -norm],
+        6  => [ zero, -norm, -norm,  norm],
+        7  => [ zero, -norm, -norm, -norm],
+        8  => [ norm,  zero,  norm,  norm],
+        9  => [ norm,  zero,  norm, -norm],
+        10 => [ norm,  zero, -norm,  norm],
+        11 => [ norm,  zero, -norm, -norm],
+        12 => [-norm,  zero,  norm,  norm],
+        13 => [-norm,  zero,  norm, -norm],
+        14 => [-norm,  zero, -norm,  norm],
+        15 => [-norm,  zero, -norm, -norm],
+        16 => [ norm,  norm,  zero,  norm],
+        17 => [ norm,  norm,  zero, -norm],
+        18 => [ norm, -norm,  zero,  norm],
+        19 => [ norm, -norm,  zero, -norm],
+        20 => [-norm,  norm,  zero,  norm],
+        21 => [-norm,  norm,  zero, -norm],
+        22 => [-norm, -norm,  zero,  norm],
+        23 => [-norm, -norm,  zero, -norm],
+        24 => [ norm,  norm,  norm,  zero],
+        25 => [ norm,  norm, -norm,  zero],
+        26 => [ norm, -norm,  norm,  zero],
+        27 => [ norm, -norm, -norm,  zero],
+        28 => [-norm,  norm,  norm,  zero],
+        29 => [-norm,  norm, -norm,  zero],
+        30 => [-norm, -norm,  norm,  zero],
+        31 => [-norm, -norm, -norm,  zero],
+        32 => [ norm2,  norm2,  norm2,  norm2],
+        33 => [-norm2,  norm2,  norm2,  norm2],
+        34 => [ norm2, -norm2,  norm2,  norm2],
+        35 => [-norm2, -norm2,  norm2,  norm2],
+        36 => [ norm2,  norm2, -norm2,  norm2],
+        37 => [-norm2,  norm2, -norm2,  norm2],
+        38 => [ norm2,  norm2,  norm2, -norm2],
+        39 => [-norm2,  norm2,  norm2, -norm2],
+        40 => [ norm2, -norm2, -norm2,  norm2],
+        41 => [-norm2, -norm2, -norm2,  norm2],
+        42 => [ norm2, -norm2,  norm2, -norm2],
+        43 => [-norm2, -norm2,  norm2, -norm2],
+        44 => [ norm2,  norm2, -norm2, -norm2],
+        45 => [-norm2,  norm2, -norm2, -norm2],
+        46 => [ norm2, -norm2, -norm2, -norm2],
+        47 => [-norm2, -norm2, -norm2, -norm2],
+        48 => [ norm2,  norm2,  norm2,  norm2],
+        49 => [-norm2,  norm2,  norm2,  norm2],
+        50 => [ norm2, -norm2,  norm2,  norm2],
+        51 => [-norm2, -norm2,  norm2,  norm2],
+        52 => [ norm2,  norm2, -norm2,  norm2],
+        53 => [-norm2,  norm2, -norm2,  norm2],
+        54 => [ norm2,  norm2,  norm2, -norm2],
+        55 => [-norm2,  norm2,  norm2, -norm2],
+        56 => [ norm2, -norm2, -norm2,  norm2],
+        57 => [-norm2, -norm2, -norm2,  norm2],
+        58 => [ norm2, -norm2,  norm2, -norm2],
+        59 => [-norm2, -norm2,  norm2, -norm2],
+        60 => [ norm2,  norm2, -norm2, -norm2],
+        61 => [-norm2,  norm2, -norm2, -norm2],
+        62 => [ norm2, -norm2, -norm2, -norm2],
+        63 => [-norm2, -norm2, -norm2, -norm2],
+        _ => panic!("Attempt to access gradient {} of 64", index % 64),
+    }
 }

--- a/src/perlin.rs
+++ b/src/perlin.rs
@@ -19,96 +19,153 @@ use {gradient, math, Seed};
 /// 2-dimensional perlin noise
 pub fn perlin2<T: Float>(seed: &Seed, point: &math::Point2<T>) -> T {
     #[inline(always)]
-    fn gradient<T: Float>(seed: &Seed, whole: math::Point2<isize>, frac: math::Vector2<T>) -> T {
-        let attn = math::cast::<_, T>(1.0) - math::dot2(frac, frac);
+    fn surflet<T: Float>(seed: &Seed, corner: math::Point2<isize>, distance: math::Vector2<T>) -> T {
+        let attn = T::one() - math::dot2(distance, distance);
         if attn > T::zero() {
-            (attn * attn) * math::dot2(frac, gradient::get2(seed.get2(whole)))
+            math::pow4(attn) * math::dot2(distance, gradient::get2(seed.get2(corner)))
         } else {
             T::zero()
         }
     }
 
     let floored = math::map2(*point, Float::floor);
-    let whole0  = math::map2(floored, math::cast);
-    let whole1  = math::add2(whole0, math::one2());
-    let frac0   = math::sub2(*point, floored);
-    let frac1   = math::sub2(frac0, math::one2());
+    let near_corner = math::map2(floored, math::cast);
+    let far_corner = math::add2(near_corner, math::one2());
+    let near_distance = math::sub2(*point, floored);
+    let far_distance = math::sub2(near_distance, math::one2());
 
-    let f00 = gradient(seed, [whole0[0], whole0[1]], [frac0[0], frac0[1]]);
-    let f10 = gradient(seed, [whole1[0], whole0[1]], [frac1[0], frac0[1]]);
-    let f01 = gradient(seed, [whole0[0], whole1[1]], [frac0[0], frac1[1]]);
-    let f11 = gradient(seed, [whole1[0], whole1[1]], [frac1[0], frac1[1]]);
+    let f00 = surflet(seed,
+                      [near_corner[0], near_corner[1]],
+                      [near_distance[0], near_distance[1]]);
+    let f10 = surflet(seed,
+                      [far_corner[0], near_corner[1]],
+                      [far_distance[0], near_distance[1]]);
+    let f01 = surflet(seed,
+                      [near_corner[0], far_corner[1]],
+                      [near_distance[0], far_distance[1]]);
+    let f11 = surflet(seed,
+                      [far_corner[0], far_corner[1]],
+                      [far_distance[0], far_distance[1]]);
 
-    // Arbitrary values to shift and scale noise to -1..1
-    (f00 + f10 + f01 + f11 + math::cast(0.053179)) * math::cast(1.056165)
+    // Multiply by arbitrary value to scale to -1..1
+    (f00 + f10 + f01 + f11) * math::cast(3.1604938271604937)
 }
 
 /// 3-dimensional perlin noise
 pub fn perlin3<T: Float>(seed: &Seed, point: &math::Point3<T>) -> T {
     #[inline(always)]
-    fn gradient<T: Float>(seed: &Seed, whole: math::Point3<isize>, frac: math::Vector3<T>) -> T {
-        let attn = math::cast::<_, T>(1.0) - math::dot3(frac, frac);
+    fn surflet<T: Float>(seed: &Seed, corner: math::Point3<isize>, distance: math::Vector3<T>) -> T {
+        let attn = T::one() - math::dot3(distance, distance);
         if attn > T::zero() {
-            (attn * attn) * math::dot3(frac, gradient::get3(seed.get3(whole)))
+            math::pow4(attn) * math::dot3(distance, gradient::get3(seed.get3(corner)))
         } else {
             T::zero()
         }
     }
 
     let floored = math::map3(*point, Float::floor);
-    let whole0  = math::map3(floored, math::cast);
-    let whole1  = math::add3(whole0, math::one3());
-    let frac0   = math::sub3(*point, floored);
-    let frac1   = math::sub3(frac0, math::one3());
+    let near_corner = math::map3(floored, math::cast);
+    let far_corner = math::add3(near_corner, math::one3());
+    let near_distance = math::sub3(*point, floored);
+    let far_distance = math::sub3(near_distance, math::one3());
 
-    let f000 = gradient(seed, [whole0[0], whole0[1], whole0[2]], [frac0[0], frac0[1], frac0[2]]);
-    let f100 = gradient(seed, [whole1[0], whole0[1], whole0[2]], [frac1[0], frac0[1], frac0[2]]);
-    let f010 = gradient(seed, [whole0[0], whole1[1], whole0[2]], [frac0[0], frac1[1], frac0[2]]);
-    let f110 = gradient(seed, [whole1[0], whole1[1], whole0[2]], [frac1[0], frac1[1], frac0[2]]);
-    let f001 = gradient(seed, [whole0[0], whole0[1], whole1[2]], [frac0[0], frac0[1], frac1[2]]);
-    let f101 = gradient(seed, [whole1[0], whole0[1], whole1[2]], [frac1[0], frac0[1], frac1[2]]);
-    let f011 = gradient(seed, [whole0[0], whole1[1], whole1[2]], [frac0[0], frac1[1], frac1[2]]);
-    let f111 = gradient(seed, [whole1[0], whole1[1], whole1[2]], [frac1[0], frac1[1], frac1[2]]);
+    let f000 = surflet(seed,
+                       [near_corner[0], near_corner[1], near_corner[2]],
+                       [near_distance[0], near_distance[1], near_distance[2]]);
+    let f100 = surflet(seed,
+                       [far_corner[0], near_corner[1], near_corner[2]],
+                       [far_distance[0], near_distance[1], near_distance[2]]);
+    let f010 = surflet(seed,
+                       [near_corner[0], far_corner[1], near_corner[2]],
+                       [near_distance[0], far_distance[1], near_distance[2]]);
+    let f110 = surflet(seed,
+                       [far_corner[0], far_corner[1], near_corner[2]],
+                       [far_distance[0], far_distance[1], near_distance[2]]);
+    let f001 = surflet(seed,
+                       [near_corner[0], near_corner[1], far_corner[2]],
+                       [near_distance[0], near_distance[1], far_distance[2]]);
+    let f101 = surflet(seed,
+                       [far_corner[0], near_corner[1], far_corner[2]],
+                       [far_distance[0], near_distance[1], far_distance[2]]);
+    let f011 = surflet(seed,
+                       [near_corner[0], far_corner[1], far_corner[2]],
+                       [near_distance[0], far_distance[1], far_distance[2]]);
+    let f111 = surflet(seed,
+                       [far_corner[0], far_corner[1], far_corner[2]],
+                       [far_distance[0], far_distance[1], far_distance[2]]);
 
-    // Arbitrary values to shift and scale noise to -1..1
-    (f000 + f100 + f010 + f110 + f001 + f101 + f011 + f111 + math::cast(0.053179)) * math::cast(1.056165)
+    // Multiply by arbitrary value to scale to -1..1
+    (f000 + f100 + f010 + f110 + f001 + f101 + f011 + f111) * math::cast(3.8898553255531074)
 }
 
 /// 4-dimensional perlin noise
 pub fn perlin4<T: Float>(seed: &Seed, point: &math::Point4<T>) -> T {
     #[inline(always)]
-    fn gradient<T: Float>(seed: &Seed, whole: math::Point4<isize>, frac: math::Vector4<T>) -> T {
-        let attn = math::cast::<_, T>(1.0) - math::dot4(frac, frac);
+    fn surflet<T: Float>(seed: &Seed, corner: math::Point4<isize>, distance: math::Vector4<T>) -> T {
+        let attn = T::one() - math::dot4(distance, distance);
         if attn > T::zero() {
-            (attn * attn) * math::dot4(frac, gradient::get4(seed.get4(whole)))
+            math::pow4(attn) * math::dot4(distance, gradient::get4(seed.get4(corner)))
         } else {
             T::zero()
         }
     }
 
     let floored = math::map4(*point, Float::floor);
-    let whole0  = math::map4(floored, math::cast);
-    let whole1  = math::add4(whole0, math::one4());
-    let frac0   = math::sub4(*point, floored);
-    let frac1   = math::sub4(frac0, math::one4());
+    let near_corner = math::map4(floored, math::cast);
+    let far_corner = math::add4(near_corner, math::one4());
+    let near_distance = math::sub4(*point, floored);
+    let far_distance = math::sub4(near_distance, math::one4());
 
-    let f0000 = gradient(seed, [whole0[0], whole0[1], whole0[2], whole0[3]], [frac0[0], frac0[1], frac0[2], frac0[3]]);
-    let f1000 = gradient(seed, [whole1[0], whole0[1], whole0[2], whole0[3]], [frac1[0], frac0[1], frac0[2], frac0[3]]);
-    let f0100 = gradient(seed, [whole0[0], whole1[1], whole0[2], whole0[3]], [frac0[0], frac1[1], frac0[2], frac0[3]]);
-    let f1100 = gradient(seed, [whole1[0], whole1[1], whole0[2], whole0[3]], [frac1[0], frac1[1], frac0[2], frac0[3]]);
-    let f0010 = gradient(seed, [whole0[0], whole0[1], whole1[2], whole0[3]], [frac0[0], frac0[1], frac1[2], frac0[3]]);
-    let f1010 = gradient(seed, [whole1[0], whole0[1], whole1[2], whole0[3]], [frac1[0], frac0[1], frac1[2], frac0[3]]);
-    let f0110 = gradient(seed, [whole0[0], whole1[1], whole1[2], whole0[3]], [frac0[0], frac1[1], frac1[2], frac0[3]]);
-    let f1110 = gradient(seed, [whole1[0], whole1[1], whole1[2], whole0[3]], [frac1[0], frac1[1], frac1[2], frac0[3]]);
-    let f0001 = gradient(seed, [whole0[0], whole0[1], whole0[2], whole1[3]], [frac0[0], frac0[1], frac0[2], frac1[3]]);
-    let f1001 = gradient(seed, [whole1[0], whole0[1], whole0[2], whole1[3]], [frac1[0], frac0[1], frac0[2], frac1[3]]);
-    let f0101 = gradient(seed, [whole0[0], whole1[1], whole0[2], whole1[3]], [frac0[0], frac1[1], frac0[2], frac1[3]]);
-    let f1101 = gradient(seed, [whole1[0], whole1[1], whole0[2], whole1[3]], [frac1[0], frac1[1], frac0[2], frac1[3]]);
-    let f0011 = gradient(seed, [whole0[0], whole0[1], whole1[2], whole1[3]], [frac0[0], frac0[1], frac1[2], frac1[3]]);
-    let f1011 = gradient(seed, [whole1[0], whole0[1], whole1[2], whole1[3]], [frac1[0], frac0[1], frac1[2], frac1[3]]);
-    let f0111 = gradient(seed, [whole0[0], whole1[1], whole1[2], whole1[3]], [frac0[0], frac1[1], frac1[2], frac1[3]]);
-    let f1111 = gradient(seed, [whole1[0], whole1[1], whole1[2], whole1[3]], [frac1[0], frac1[1], frac1[2], frac1[3]]);
+    let f0000 = surflet(seed,
+                        [near_corner[0], near_corner[1], near_corner[2], near_corner[3]],
+                        [near_distance[0], near_distance[1], near_distance[2], near_distance[3]]);
+    let f1000 = surflet(seed,
+                        [far_corner[0], near_corner[1], near_corner[2], near_corner[3]],
+                        [far_distance[0], near_distance[1], near_distance[2], near_distance[3]]);
+    let f0100 = surflet(seed,
+                        [near_corner[0], far_corner[1], near_corner[2], near_corner[3]],
+                        [near_distance[0], far_distance[1], near_distance[2], near_distance[3]]);
+    let f1100 = surflet(seed,
+                        [far_corner[0], far_corner[1], near_corner[2], near_corner[3]],
+                        [far_distance[0], far_distance[1], near_distance[2], near_distance[3]]);
+    let f0010 = surflet(seed,
+                        [near_corner[0], near_corner[1], far_corner[2], near_corner[3]],
+                        [near_distance[0], near_distance[1], far_distance[2], near_distance[3]]);
+    let f1010 = surflet(seed,
+                        [far_corner[0], near_corner[1], far_corner[2], near_corner[3]],
+                        [far_distance[0], near_distance[1], far_distance[2], near_distance[3]]);
+    let f0110 = surflet(seed,
+                        [near_corner[0], far_corner[1], far_corner[2], near_corner[3]],
+                        [near_distance[0], far_distance[1], far_distance[2], near_distance[3]]);
+    let f1110 = surflet(seed,
+                        [far_corner[0], far_corner[1], far_corner[2], near_corner[3]],
+                        [far_distance[0], far_distance[1], far_distance[2], near_distance[3]]);
+    let f0001 = surflet(seed,
+                        [near_corner[0], near_corner[1], near_corner[2], far_corner[3]],
+                        [near_distance[0], near_distance[1], near_distance[2], far_distance[3]]);
+    let f1001 = surflet(seed,
+                        [far_corner[0], near_corner[1], near_corner[2], far_corner[3]],
+                        [far_distance[0], near_distance[1], near_distance[2], far_distance[3]]);
+    let f0101 = surflet(seed,
+                        [near_corner[0], far_corner[1], near_corner[2], far_corner[3]],
+                        [near_distance[0], far_distance[1], near_distance[2], far_distance[3]]);
+    let f1101 = surflet(seed,
+                        [far_corner[0], far_corner[1], near_corner[2], far_corner[3]],
+                        [far_distance[0], far_distance[1], near_distance[2], far_distance[3]]);
+    let f0011 = surflet(seed,
+                        [near_corner[0], near_corner[1], far_corner[2], far_corner[3]],
+                        [near_distance[0], near_distance[1], far_distance[2], far_distance[3]]);
+    let f1011 = surflet(seed,
+                        [far_corner[0], near_corner[1], far_corner[2], far_corner[3]],
+                        [far_distance[0], near_distance[1], far_distance[2], far_distance[3]]);
+    let f0111 = surflet(seed,
+                        [near_corner[0], far_corner[1], far_corner[2], far_corner[3]],
+                        [near_distance[0], far_distance[1], far_distance[2], far_distance[3]]);
+    let f1111 = surflet(seed,
+                        [far_corner[0], far_corner[1], far_corner[2], far_corner[3]],
+                        [far_distance[0], far_distance[1], far_distance[2], far_distance[3]]);
 
-    // Arbitrary value to scale noise to -1..1
-    (f0000 + f1000 + f0100 + f1100 + f0010 + f1010 + f0110 + f1110 + f0001 + f1001 + f0101 + f1101 + f0011 + f1011 + f0111 + f1111) * math::cast(1.119016)
+    // Multiply by arbitrary value to scale to -1..1
+    (f0000 + f1000 + f0100 + f1100 + f0010 + f1010 + f0110 + f1110 + f0001 + f1001 +
+     f0101 + f1101 + f0011 + f1011 + f0111 + f1111) * math::cast(4.424369240215691)
 }


### PR DESCRIPTION
While looking in to fixing #96 I decided to give perlin noise a general cleanup. As a part of this I changed the falloff function from 1 - x^2 to 1 - x^4 to match simplex noise and normalized the gradients. Making these changes re-added the requirement for a scaling factor which was calculated by sampling 2^32 points to determine the natural range. I also fixed the fBm implementation to scale it's output to the same as the noise used to generate it.

While I was verifying these changes I also changed the benchmarks to f64 as that gives more consistent results on my machine and modified the perlin example to provide a value for every dimension so they can cover the entire range of the noise. I then replicated these changes to all of the other examples for consistency.

This feels like it's too much for one PR but there is only one thing that might warrant discussion here (perlin changes) so I tossed the rest in with it.