### PR TITLE
Mutation, Composition, and Utility Generators

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,18 @@ name = "cell_manhattan_value"
 [[example]]
 name = "value"
 
+[[example]]
+name = "constant"
+
+[[example]]
+name = "checkerboard"
+
+[[example]]
+name = "cylinders"
+
+[[example]]
+name = "select"
+
 [[bench]]
 name = "benches"
 

--- a/examples/checkerboard.rs
+++ b/examples/checkerboard.rs
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! An example of using perlin noise
+//! An example of generating constant valued noise
 
 extern crate noise;
 
-use noise::modules::Perlin;
+use noise::modules::Checkerboard;
 
 mod debug;
 
 fn main() {
-    debug::render_png2("perlin.png", Perlin::new(0), 1024, 1024, 50);
+    debug::render_png2("checkerboard.png", Checkerboard::new(0), 1024, 1024, 100);
 }

--- a/examples/constant.rs
+++ b/examples/constant.rs
@@ -12,14 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! An example of using perlin noise
+//! An example of generating constant valued noise
 
 extern crate noise;
 
-use noise::modules::Perlin;
+use noise::modules::Constant;
 
 mod debug;
 
 fn main() {
-    debug::render_png2("perlin.png", Perlin::new(0), 1024, 1024, 50);
+    debug::render_png2("constant1.png", Constant::new(-1.0), 1024, 1024, 1);
+    debug::render_png2("constant2.png", Constant::new(0.0), 1024, 1024, 1);
+    debug::render_png2("constant3.png", Constant::new(1.0), 1024, 1024, 1);
 }

--- a/examples/cylinders.rs
+++ b/examples/cylinders.rs
@@ -12,14 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! An example of using perlin noise
-
 extern crate noise;
 
-use noise::modules::Perlin;
+use noise::modules::Cylinders;
 
 mod debug;
 
 fn main() {
-    debug::render_png2("perlin.png", Perlin::new(0), 1024, 1024, 50);
+    debug::render_png2("cylinders.png", Cylinders::new(1.0), 1024, 1024, 50);
 }

--- a/examples/debug/mod.rs
+++ b/examples/debug/mod.rs
@@ -18,6 +18,7 @@ extern crate image;
 extern crate num_traits;
 
 use noise;
+use noise::Module;
 use self::num_traits::{Float, NumCast};
 use std::path::Path;
 
@@ -42,6 +43,29 @@ pub fn render_png<T, F>(filename: &str, perm_table: &noise::PermutationTable, wi
     for y in 0..height {
         for x in 0..width {
             let value: f64 = cast(func(perm_table, &[cast::<_,T>(x) - cast::<_,T>(width/2), cast::<_,T>(y) - cast::<_,T>(height/2)]));
+            pixels.push(cast(clamp(value * 0.5 + 0.5, 0.0, 1.0) * 255.0));
+        }
+    }
+
+    let _ = image::save_buffer(&Path::new(filename),
+                               &*pixels,
+                               width,
+                               height,
+                               image::Gray(8));
+
+    println!("\nGenerated {}", filename);
+}
+
+pub fn render_png2<M>(filename: &str, module: M, width: u32, height: u32, zoom: u32)
+    where M: Module<[f64; 3], Output = f64>
+{
+    let mut pixels = Vec::with_capacity((width * height) as usize);
+
+    for y in 0..height {
+        for x in 0..width {
+            let value: f64 = cast(module.get([((x as f64 - (width as f64 / 2.0)) / zoom as f64),
+                                              ((y as f64 - (height as f64 / 2.0)) / zoom as f64),
+                                              0.0]));
             pixels.push(cast(clamp(value * 0.5 + 0.5, 0.0, 1.0) * 255.0));
         }
     }

--- a/examples/debug/mod.rs
+++ b/examples/debug/mod.rs
@@ -18,7 +18,7 @@ extern crate image;
 extern crate num_traits;
 
 use noise;
-use noise::Module;
+use noise::NoiseModule;
 use self::num_traits::{Float, NumCast};
 use std::path::Path;
 
@@ -57,7 +57,7 @@ pub fn render_png<T, F>(filename: &str, perm_table: &noise::PermutationTable, wi
 }
 
 pub fn render_png2<M>(filename: &str, module: M, width: u32, height: u32, zoom: u32)
-    where M: Module<[f64; 3], Output = f64>
+    where M: NoiseModule<[f64; 3], Output = f64>
 {
     let mut pixels = Vec::with_capacity((width * height) as usize);
 

--- a/examples/select.rs
+++ b/examples/select.rs
@@ -1,4 +1,4 @@
-// Copyright 2015 The Noise-rs Developers.
+// Copyright 2013 The Noise-rs Developers.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,14 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! An example of using perlin noise
-
 extern crate noise;
 
-use noise::modules::Perlin;
+use noise::modules::*;
 
 mod debug;
 
 fn main() {
-    debug::render_png2("perlin.png", Perlin::new(0), 1024, 1024, 50);
+    let checkerboard = Checkerboard::new(0);
+    let cylinders = Cylinders::new(1.0);
+    let perlin = Perlin::new(0);
+    let constant = Constant::new(0.5);
+    let select1 = Select::new(perlin, cylinders, checkerboard, 0.5, 0.0, 1.0);
+    let select2 = Select::new(perlin, constant, checkerboard, 0.0, 0.0, 1.0);
+
+    debug::render_png2("select1.png", select1, 1024, 1024, 100);
+    debug::render_png2("select2.png", select2, 1024, 1024, 100);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,8 @@ mod value;
 mod open_simplex;
 mod cell;
 
+pub mod modules;
+
 /// A trait alias for a 2-dimensional noise function.
 ///
 /// This is useful for succinctly parameterising over valid noise functions.
@@ -97,3 +99,31 @@ pub trait GenFn4<T>: Fn(&PermutationTable, &Point4<T>) -> T {}
 impl<T, F> GenFn2<T> for F where F: Fn(&PermutationTable, &Point2<T>) -> T, {}
 impl<T, F> GenFn3<T> for F where F: Fn(&PermutationTable, &Point3<T>) -> T, {}
 impl<T, F> GenFn4<T> for F where F: Fn(&PermutationTable, &Point4<T>) -> T, {}
+
+/// Base trait for noise modules.
+///
+/// A noise module is a object that calculates and outputs a value given a
+/// n-Dimensional input value, where n is (2,3,4).
+///
+/// Each type of noise module uses a specific method to calculate an output
+/// value. Some of these methods include:
+///
+/// * Calculating a value using a coherent-noise function or some other
+///     mathematical function.
+/// * Mathematically changing the output value from another noise module
+///     in various ways.
+/// * Combining the output values from two noise modules in various ways.
+pub trait Module<T> {
+    type Output;
+
+    fn get(&self, point: T) -> Self::Output;
+}
+
+impl<'a, T, M: Module<T>> Module<T> for &'a M {
+    type Output = M::Output;
+
+    #[inline]
+    fn get(&self, point: T) -> M::Output {
+        M::get(*self, point)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,13 +113,13 @@ impl<T, F> GenFn4<T> for F where F: Fn(&PermutationTable, &Point4<T>) -> T, {}
 /// * Mathematically changing the output value from another noise module
 ///     in various ways.
 /// * Combining the output values from two noise modules in various ways.
-pub trait Module<T> {
+pub trait NoiseModule<T> {
     type Output;
 
     fn get(&self, point: T) -> Self::Output;
 }
 
-impl<'a, T, M: Module<T>> Module<T> for &'a M {
+impl<'a, T, M: NoiseModule<T>> NoiseModule<T> for &'a M {
     type Output = M::Output;
 
     #[inline]

--- a/src/math.rs
+++ b/src/math.rs
@@ -216,3 +216,23 @@ pub fn cast4<T, U>(x: Point4<T>) -> Point4<U>
 {
     map4(x, cast)
 }
+
+pub mod interp {
+    use num_traits::Float;
+    use math;
+
+    /// Performs linear interploation between two values.
+    pub fn linear<T: Float>(a: T, b: T, x: T) -> T {
+        x.mul_add((b - a), a)
+    }
+
+    /// Maps a value onto a cubic S-curve.
+    pub fn s_curve3<T: Float>(x: T) -> T {
+        x * x * (math::cast::<_, T>(3.0) - (x * math::cast(2.0)))
+    }
+
+    /// Maps a value onto a quintic S-curve.
+    pub fn s_curve5<T: Float>(x: T) -> T {
+        x * x * x * (x * (x * math::cast(6.0) - math::cast(15.0) + math::cast(10.0)))
+    }
+}

--- a/src/modules/generators/checkerboard.rs
+++ b/src/modules/generators/checkerboard.rs
@@ -14,8 +14,8 @@
 
 use num_traits::Float;
 use math;
-use Module;
 use math::{Point2, Point3, Point4};
+use NoiseModule;
 
 /// Noise module that outputs a checkerboard pattern.
 ///
@@ -47,7 +47,7 @@ fn fast_floor<T: Float>(x: T) -> usize {
 
 // These impl's should be made generic over Point, but there is no higher Point type.
 // Keep the code the same anyway.
-impl<T: Float> Module<Point2<T>> for Checkerboard {
+impl<T: Float> NoiseModule<Point2<T>> for Checkerboard {
     type Output = T;
 
     fn get(&self, point: Point2<T>) -> Self::Output {
@@ -63,7 +63,7 @@ impl<T: Float> Module<Point2<T>> for Checkerboard {
     }
 }
 
-impl<T: Float> Module<Point3<T>> for Checkerboard {
+impl<T: Float> NoiseModule<Point3<T>> for Checkerboard {
     type Output = T;
 
     fn get(&self, point: Point3<T>) -> Self::Output {
@@ -79,7 +79,7 @@ impl<T: Float> Module<Point3<T>> for Checkerboard {
     }
 }
 
-impl<T: Float> Module<Point4<T>> for Checkerboard {
+impl<T: Float> NoiseModule<Point4<T>> for Checkerboard {
     type Output = T;
 
     fn get(&self, point: Point4<T>) -> Self::Output {

--- a/src/modules/generators/checkerboard.rs
+++ b/src/modules/generators/checkerboard.rs
@@ -1,0 +1,96 @@
+// Copyright 2013 The Noise-rs Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use num_traits::Float;
+use math;
+use Module;
+use math::{Point2, Point3, Point4};
+
+/// Noise module that outputs a checkerboard pattern.
+///
+/// This noise module takes one input, size, and outputs 2<sup>size</sup>-sized blocks
+/// of alternating values. The values of these blocks alternate between -1.0
+/// and 1.0.
+///
+/// This noise module is not very useful by itself, but it can be used for
+/// debugging purposes.
+#[derive(Clone, Copy, Debug)]
+pub struct Checkerboard {
+    /// Controls the size of the block in 2^(size).
+    pub size: usize,
+}
+
+impl Checkerboard {
+    pub fn new(size: usize) -> Checkerboard {
+        Checkerboard { size: 1 << size }
+    }
+}
+
+fn fast_floor<T: Float>(x: T) -> usize {
+    if x > T::zero() {
+        math::cast(x)
+    } else {
+        math::cast(x - T::one())
+    }
+}
+
+// These impl's should be made generic over Point, but there is no higher Point type.
+// Keep the code the same anyway.
+impl<T: Float> Module<Point2<T>> for Checkerboard {
+    type Output = T;
+
+    fn get(&self, point: Point2<T>) -> Self::Output {
+        let result = point.iter()
+            .map(|&a| fast_floor(a))
+            .fold(0, |a, b| (a & self.size) ^ (b & self.size));
+
+        if result > 0 {
+            -T::one()
+        } else {
+            T::one()
+        }
+    }
+}
+
+impl<T: Float> Module<Point3<T>> for Checkerboard {
+    type Output = T;
+
+    fn get(&self, point: Point3<T>) -> Self::Output {
+        let result = point.iter()
+            .map(|&a| fast_floor(a))
+            .fold(0, |a, b| (a & self.size) ^ (b & self.size));
+
+        if result > 0 {
+            -T::one()
+        } else {
+            T::one()
+        }
+    }
+}
+
+impl<T: Float> Module<Point4<T>> for Checkerboard {
+    type Output = T;
+
+    fn get(&self, point: Point4<T>) -> Self::Output {
+        let result = point.iter()
+            .map(|&a| fast_floor(a))
+            .fold(0, |a, b| (a & self.size) ^ (b & self.size));
+
+        if result > 0 {
+            -T::one()
+        } else {
+            T::one()
+        }
+    }
+}

--- a/src/modules/generators/constant.rs
+++ b/src/modules/generators/constant.rs
@@ -13,8 +13,7 @@
 // limitations under the License.
 
 use num_traits::Float;
-
-use Module;
+use NoiseModule;
 
 /// Noise module that outputs a constant value.
 ///
@@ -35,7 +34,7 @@ impl<T: Float> Constant<T> {
     }
 }
 
-impl<T, U> Module<U> for Constant<T>
+impl<T, U> NoiseModule<U> for Constant<T>
     where T: Float,
           U: Copy,
 {

--- a/src/modules/generators/constant.rs
+++ b/src/modules/generators/constant.rs
@@ -1,0 +1,47 @@
+// Copyright 2013 The Noise-rs Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use num_traits::Float;
+
+use Module;
+
+/// Noise module that outputs a constant value.
+///
+/// This module takes a input, value, and returns that input for all points,
+/// producing a contant-valued field.
+///
+/// This module is not very useful by itself, but can be used as a source
+/// module for other noise modules.
+#[derive(Clone, Copy, Debug)]
+pub struct Constant<T: Float> {
+    /// Constant value.
+    pub value: T,
+}
+
+impl<T: Float> Constant<T> {
+    pub fn new(value: T) -> Constant<T> {
+        Constant { value: value }
+    }
+}
+
+impl<T, U> Module<U> for Constant<T>
+    where T: Float,
+          U: Copy,
+{
+    type Output = T;
+
+    fn get(&self, _point: U) -> Self::Output {
+        self.value
+    }
+}

--- a/src/modules/generators/cylinders.rs
+++ b/src/modules/generators/cylinders.rs
@@ -15,8 +15,7 @@
 use num_traits::Float;
 use math;
 use math::{Point2, Point3, Point4};
-
-use Module;
+use NoiseModule;
 
 /// Noise module that outputs concentric rings, cylinders, or spheres.
 ///
@@ -36,7 +35,7 @@ impl<T: Float> Cylinders<T> {
     }
 }
 
-impl<T: Float> Module<Point2<T>> for Cylinders<T> {
+impl<T: Float> NoiseModule<Point2<T>> for Cylinders<T> {
     type Output = T;
 
     fn get(&self, point: Point2<T>) -> Self::Output {
@@ -49,7 +48,7 @@ impl<T: Float> Module<Point2<T>> for Cylinders<T> {
     }
 }
 
-impl<T: Float> Module<Point3<T>> for Cylinders<T> {
+impl<T: Float> NoiseModule<Point3<T>> for Cylinders<T> {
     type Output = T;
 
     fn get(&self, point: Point3<T>) -> Self::Output {
@@ -64,7 +63,7 @@ impl<T: Float> Module<Point3<T>> for Cylinders<T> {
     }
 }
 
-impl<T: Float> Module<Point4<T>> for Cylinders<T> {
+impl<T: Float> NoiseModule<Point4<T>> for Cylinders<T> {
     type Output = T;
 
     fn get(&self, point: Point4<T>) -> Self::Output {

--- a/src/modules/generators/cylinders.rs
+++ b/src/modules/generators/cylinders.rs
@@ -1,0 +1,81 @@
+// Copyright 2015 The Noise-rs Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use num_traits::Float;
+use math;
+use math::{Point2, Point3, Point4};
+
+use Module;
+
+/// Noise module that outputs concentric rings, cylinders, or spheres.
+///
+/// This noise module outputs concentric rings, cylinders, or spheres centered
+/// on the origin. The cylinders are oriented along the z axis similar to the
+/// concentric rings of a tree. Each cylinder extends infinitely along the y
+/// axis.
+#[derive(Clone, Copy, Debug)]
+pub struct Cylinders<T: Float> {
+    /// Frequency of the concentric objects.
+    pub frequency: T,
+}
+
+impl<T: Float> Cylinders<T> {
+    pub fn new(v: T) -> Cylinders<T> {
+        Cylinders { frequency: v }
+    }
+}
+
+impl<T: Float> Module<Point2<T>> for Cylinders<T> {
+    type Output = T;
+
+    fn get(&self, point: Point2<T>) -> Self::Output {
+        let x = point[0] * self.frequency;
+
+        let dist_from_smaller_sphere = x - x.floor();
+        let dist_from_larger_sphere = T::one() - dist_from_smaller_sphere;
+        let nearest_dist = dist_from_smaller_sphere.min(dist_from_larger_sphere);
+        T::one() - (nearest_dist * math::cast(4.0))
+    }
+}
+
+impl<T: Float> Module<Point3<T>> for Cylinders<T> {
+    type Output = T;
+
+    fn get(&self, point: Point3<T>) -> Self::Output {
+        let x = point[0] * self.frequency;
+        let y = point[1] * self.frequency;
+
+        let dist_from_center = (x * x + y * y).sqrt();
+        let dist_from_smaller_sphere = dist_from_center - dist_from_center.floor();
+        let dist_from_larger_sphere = T::one() - dist_from_smaller_sphere;
+        let nearest_dist = dist_from_smaller_sphere.min(dist_from_larger_sphere);
+        T::one() - (nearest_dist * math::cast(4.0))
+    }
+}
+
+impl<T: Float> Module<Point4<T>> for Cylinders<T> {
+    type Output = T;
+
+    fn get(&self, point: Point4<T>) -> Self::Output {
+        let x = point[0] * self.frequency;
+        let y = point[1] * self.frequency;
+        let z = point[2] * self.frequency;
+
+        let dist_from_center = (x * x + y * y + z * z).sqrt();
+        let dist_from_smaller_sphere = dist_from_center - dist_from_center.floor();
+        let dist_from_larger_sphere = T::one() - dist_from_smaller_sphere;
+        let nearest_dist = dist_from_smaller_sphere.min(dist_from_larger_sphere);
+        T::one() - (nearest_dist * math::cast(4.0))
+    }
+}

--- a/src/modules/generators/mod.rs
+++ b/src/modules/generators/mod.rs
@@ -12,14 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! An example of using perlin noise
+pub use self::checkerboard::*;
+pub use self::constant::*;
+pub use self::cylinders::*;
+pub use self::perlin::*;
 
-extern crate noise;
-
-use noise::modules::Perlin;
-
-mod debug;
-
-fn main() {
-    debug::render_png2("perlin.png", Perlin::new(0), 1024, 1024, 50);
-}
+mod constant;
+mod checkerboard;
+mod cylinders;
+mod perlin;

--- a/src/modules/generators/perlin.rs
+++ b/src/modules/generators/perlin.rs
@@ -1,0 +1,213 @@
+// Copyright 2015 The Noise-rs Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use num_traits::Float;
+use math;
+use Module;
+use math::{Point2, Point3, Point4};
+
+use {PermutationTable, gradient};
+
+/// Noise module that outputs 2/3/4-dimensional Perlin noise.
+#[derive(Clone, Copy, Debug)]
+pub struct Perlin {
+    perm_table: PermutationTable,
+}
+
+impl Perlin {
+    pub fn new(seed: usize) -> Perlin {
+        Perlin { perm_table: PermutationTable::new(seed as u32) }
+    }
+}
+
+/// 2-dimensional perlin noise
+impl<T: Float> Module<Point2<T>> for Perlin {
+    type Output = T;
+
+    fn get(&self, point: Point2<T>) -> T {
+        #[inline(always)]
+        fn surflet<T: Float>(perm_table: &PermutationTable,
+                             corner: math::Point2<isize>,
+                             distance: math::Vector2<T>)
+                             -> T {
+            let attn = T::one() - math::dot2(distance, distance);
+            if attn > T::zero() {
+                math::pow4(attn) * math::dot2(distance, gradient::get2(perm_table.get2(corner)))
+            } else {
+                T::zero()
+            }
+        }
+
+        let floored = math::map2(point, T::floor);
+        let near_corner = math::map2(floored, math::cast);
+        let far_corner = math::add2(near_corner, math::one2());
+        let near_distance = math::sub2(point, floored);
+        let far_distance = math::sub2(near_distance, math::one2());
+
+        let f00 = surflet(&self.perm_table,
+                          [near_corner[0], near_corner[1]],
+                          [near_distance[0], near_distance[1]]);
+        let f10 = surflet(&self.perm_table,
+                          [far_corner[0], near_corner[1]],
+                          [far_distance[0], near_distance[1]]);
+        let f01 = surflet(&self.perm_table,
+                          [near_corner[0], far_corner[1]],
+                          [near_distance[0], far_distance[1]]);
+        let f11 = surflet(&self.perm_table,
+                          [far_corner[0], far_corner[1]],
+                          [far_distance[0], far_distance[1]]);
+
+        // Multiply by arbitrary value to scale to -1..1
+        (f00 + f10 + f01 + f11) * math::cast(3.1604938271604937)
+    }
+}
+
+/// 3-dimensional perlin noise
+impl<T: Float> Module<Point3<T>> for Perlin {
+    type Output = T;
+
+    fn get(&self, point: Point3<T>) -> T {
+        #[inline(always)]
+        fn surflet<T: Float>(perm_table: &PermutationTable,
+                             corner: math::Point3<isize>,
+                             distance: math::Vector3<T>)
+                             -> T {
+            let attn = T::one() - math::dot3(distance, distance);
+            if attn > T::zero() {
+                math::pow4(attn) * math::dot3(distance, gradient::get3(perm_table.get3(corner)))
+            } else {
+                T::zero()
+            }
+        }
+
+        let floored = math::map3(point, T::floor);
+        let near_corner = math::map3(floored, math::cast);
+        let far_corner = math::add3(near_corner, math::one3());
+        let near_distance = math::sub3(point, floored);
+        let far_distance = math::sub3(near_distance, math::one3());
+
+        let f000 = surflet(&self.perm_table,
+                           [near_corner[0], near_corner[1], near_corner[2]],
+                           [near_distance[0], near_distance[1], near_distance[2]]);
+        let f100 = surflet(&self.perm_table,
+                           [far_corner[0], near_corner[1], near_corner[2]],
+                           [far_distance[0], near_distance[1], near_distance[2]]);
+        let f010 = surflet(&self.perm_table,
+                           [near_corner[0], far_corner[1], near_corner[2]],
+                           [near_distance[0], far_distance[1], near_distance[2]]);
+        let f110 = surflet(&self.perm_table,
+                           [far_corner[0], far_corner[1], near_corner[2]],
+                           [far_distance[0], far_distance[1], near_distance[2]]);
+        let f001 = surflet(&self.perm_table,
+                           [near_corner[0], near_corner[1], far_corner[2]],
+                           [near_distance[0], near_distance[1], far_distance[2]]);
+        let f101 = surflet(&self.perm_table,
+                           [far_corner[0], near_corner[1], far_corner[2]],
+                           [far_distance[0], near_distance[1], far_distance[2]]);
+        let f011 = surflet(&self.perm_table,
+                           [near_corner[0], far_corner[1], far_corner[2]],
+                           [near_distance[0], far_distance[1], far_distance[2]]);
+        let f111 = surflet(&self.perm_table,
+                           [far_corner[0], far_corner[1], far_corner[2]],
+                           [far_distance[0], far_distance[1], far_distance[2]]);
+
+        // Multiply by arbitrary value to scale to -1..1
+        (f000 + f100 + f010 + f110 + f001 + f101 + f011 + f111) * math::cast(3.8898553255531074)
+    }
+}
+
+/// 4-dimensional perlin noise
+impl<T: Float> Module<Point4<T>> for Perlin {
+    type Output = T;
+
+    fn get(&self, point: Point4<T>) -> T {
+        #[inline(always)]
+        fn surflet<T: Float>(perm_table: &PermutationTable,
+                             corner: math::Point4<isize>,
+                             distance: math::Vector4<T>)
+                             -> T {
+            let attn = T::one() - math::dot4(distance, distance);
+            if attn > T::zero() {
+                math::pow4(attn) * math::dot4(distance, gradient::get4(perm_table.get4(corner)))
+            } else {
+                T::zero()
+            }
+        }
+
+        let floored = math::map4(point, T::floor);
+        let near_corner = math::map4(floored, math::cast);
+        let far_corner = math::add4(near_corner, math::one4());
+        let near_distance = math::sub4(point, floored);
+        let far_distance = math::sub4(near_distance, math::one4());
+
+        let f0000 =
+            surflet(&self.perm_table,
+                    [near_corner[0], near_corner[1], near_corner[2], near_corner[3]],
+                    [near_distance[0], near_distance[1], near_distance[2], near_distance[3]]);
+        let f1000 =
+            surflet(&self.perm_table,
+                    [far_corner[0], near_corner[1], near_corner[2], near_corner[3]],
+                    [far_distance[0], near_distance[1], near_distance[2], near_distance[3]]);
+        let f0100 =
+            surflet(&self.perm_table,
+                    [near_corner[0], far_corner[1], near_corner[2], near_corner[3]],
+                    [near_distance[0], far_distance[1], near_distance[2], near_distance[3]]);
+        let f1100 = surflet(&self.perm_table,
+                            [far_corner[0], far_corner[1], near_corner[2], near_corner[3]],
+                            [far_distance[0], far_distance[1], near_distance[2], near_distance[3]]);
+        let f0010 =
+            surflet(&self.perm_table,
+                    [near_corner[0], near_corner[1], far_corner[2], near_corner[3]],
+                    [near_distance[0], near_distance[1], far_distance[2], near_distance[3]]);
+        let f1010 = surflet(&self.perm_table,
+                            [far_corner[0], near_corner[1], far_corner[2], near_corner[3]],
+                            [far_distance[0], near_distance[1], far_distance[2], near_distance[3]]);
+        let f0110 = surflet(&self.perm_table,
+                            [near_corner[0], far_corner[1], far_corner[2], near_corner[3]],
+                            [near_distance[0], far_distance[1], far_distance[2], near_distance[3]]);
+        let f1110 = surflet(&self.perm_table,
+                            [far_corner[0], far_corner[1], far_corner[2], near_corner[3]],
+                            [far_distance[0], far_distance[1], far_distance[2], near_distance[3]]);
+        let f0001 =
+            surflet(&self.perm_table,
+                    [near_corner[0], near_corner[1], near_corner[2], far_corner[3]],
+                    [near_distance[0], near_distance[1], near_distance[2], far_distance[3]]);
+        let f1001 = surflet(&self.perm_table,
+                            [far_corner[0], near_corner[1], near_corner[2], far_corner[3]],
+                            [far_distance[0], near_distance[1], near_distance[2], far_distance[3]]);
+        let f0101 = surflet(&self.perm_table,
+                            [near_corner[0], far_corner[1], near_corner[2], far_corner[3]],
+                            [near_distance[0], far_distance[1], near_distance[2], far_distance[3]]);
+        let f1101 = surflet(&self.perm_table,
+                            [far_corner[0], far_corner[1], near_corner[2], far_corner[3]],
+                            [far_distance[0], far_distance[1], near_distance[2], far_distance[3]]);
+        let f0011 = surflet(&self.perm_table,
+                            [near_corner[0], near_corner[1], far_corner[2], far_corner[3]],
+                            [near_distance[0], near_distance[1], far_distance[2], far_distance[3]]);
+        let f1011 = surflet(&self.perm_table,
+                            [far_corner[0], near_corner[1], far_corner[2], far_corner[3]],
+                            [far_distance[0], near_distance[1], far_distance[2], far_distance[3]]);
+        let f0111 = surflet(&self.perm_table,
+                            [near_corner[0], far_corner[1], far_corner[2], far_corner[3]],
+                            [near_distance[0], far_distance[1], far_distance[2], far_distance[3]]);
+        let f1111 = surflet(&self.perm_table,
+                            [far_corner[0], far_corner[1], far_corner[2], far_corner[3]],
+                            [far_distance[0], far_distance[1], far_distance[2], far_distance[3]]);
+
+        // Multiply by arbitrary value to scale to -1..1
+        (f0000 + f1000 + f0100 + f1100 + f0010 + f1010 + f0110 + f1110 + f0001 +
+         f1001 + f0101 + f1101 + f0011 + f1011 + f0111 + f1111) *
+        math::cast(4.424369240215691)
+    }
+}

--- a/src/modules/generators/perlin.rs
+++ b/src/modules/generators/perlin.rs
@@ -14,10 +14,8 @@
 
 use num_traits::Float;
 use math;
-use Module;
 use math::{Point2, Point3, Point4};
-
-use {PermutationTable, gradient};
+use {NoiseModule, PermutationTable, gradient};
 
 /// Noise module that outputs 2/3/4-dimensional Perlin noise.
 #[derive(Clone, Copy, Debug)]
@@ -32,7 +30,7 @@ impl Perlin {
 }
 
 /// 2-dimensional perlin noise
-impl<T: Float> Module<Point2<T>> for Perlin {
+impl<T: Float> NoiseModule<Point2<T>> for Perlin {
     type Output = T;
 
     fn get(&self, point: Point2<T>) -> T {
@@ -74,7 +72,7 @@ impl<T: Float> Module<Point2<T>> for Perlin {
 }
 
 /// 3-dimensional perlin noise
-impl<T: Float> Module<Point3<T>> for Perlin {
+impl<T: Float> NoiseModule<Point3<T>> for Perlin {
     type Output = T;
 
     fn get(&self, point: Point3<T>) -> T {
@@ -128,7 +126,7 @@ impl<T: Float> Module<Point3<T>> for Perlin {
 }
 
 /// 4-dimensional perlin noise
-impl<T: Float> Module<Point4<T>> for Perlin {
+impl<T: Float> NoiseModule<Point4<T>> for Perlin {
     type Output = T;
 
     fn get(&self, point: Point4<T>) -> T {

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -12,14 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! An example of using perlin noise
+pub use self::generators::*;
+pub use self::selectors::*;
 
-extern crate noise;
-
-use noise::modules::Perlin;
-
-mod debug;
-
-fn main() {
-    debug::render_png2("perlin.png", Perlin::new(0), 1024, 1024, 50);
-}
+mod generators;
+mod selectors;

--- a/src/modules/selectors/mod.rs
+++ b/src/modules/selectors/mod.rs
@@ -12,14 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! An example of using perlin noise
+pub use self::select::*;
 
-extern crate noise;
-
-use noise::modules::Perlin;
-
-mod debug;
-
-fn main() {
-    debug::render_png2("perlin.png", Perlin::new(0), 1024, 1024, 50);
-}
+mod select;

--- a/src/modules/selectors/select.rs
+++ b/src/modules/selectors/select.rs
@@ -1,0 +1,110 @@
+// Copyright 2013 The Noise-rs Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use num_traits::Float;
+use math::interp;
+use Module;
+
+/// Noise module that outputs the value selected from one of two source
+/// modules chosen by the output value from a control module.
+#[derive(Clone, Copy, Debug)]
+pub struct Select<Source1, Source2, Control, T> {
+    /// Outputs a value.
+    pub source1: Source1,
+
+    /// Outputs a value.
+    pub source2: Source2,
+
+    /// Determines the value to select. If the output value from
+    /// the control module is within a range of values know as the _selection
+    /// range_, this noise module outputs the value from `source2`.
+    /// Otherwise, this noise module outputs the value from `source1`.
+    pub control: Control,
+
+    /// Edge-falloff value.
+    pub edge_falloff: T,
+
+    /// Lower bound of the selection range.
+    pub lower_bound: T,
+
+    /// Upper bound of the selection range.
+    pub upper_bound: T,
+}
+
+impl<Source1, Source2, Control, T> Select<Source1, Source2, Control, T> {
+    pub fn new(source1: Source1,
+               source2: Source2,
+               control: Control,
+               falloff: T,
+               lower: T,
+               upper: T)
+               -> Select<Source1, Source2, Control, T> {
+        Select {
+            source1: source1,
+            source2: source2,
+            control: control,
+            edge_falloff: falloff,
+            lower_bound: lower,
+            upper_bound: upper,
+        }
+    }
+}
+
+impl<Source1, Source2, Control, T, U> Module<T> for Select<Source1, Source2, Control, U>
+    where Source1: Module<T, Output = U>,
+          Source2: Module<T, Output = U>,
+          Control: Module<T, Output = U>,
+          T: Copy,
+          U: Float,
+{
+    type Output = U;
+
+    fn get(&self, point: T) -> Self::Output {
+        let control_value = self.control.get(point);
+
+        if self.edge_falloff > U::zero() {
+            match () {
+                _ if control_value < (self.lower_bound - self.edge_falloff) => {
+                    self.source1.get(point)
+                },
+                _ if control_value < (self.lower_bound + self.edge_falloff) => {
+                    let lower_curve: U = self.lower_bound - self.edge_falloff;
+                    let upper_curve: U = self.lower_bound + self.edge_falloff;
+                    let alpha = interp::s_curve3((control_value - lower_curve) /
+                                                 (upper_curve - lower_curve));
+
+                    interp::linear(self.source1.get(point), self.source2.get(point), alpha)
+                },
+                _ if control_value < (self.upper_bound - self.edge_falloff) => {
+                    self.source2.get(point)
+                },
+                _ if control_value < (self.upper_bound + self.edge_falloff) => {
+                    let lower_curve: U = self.upper_bound - self.edge_falloff;
+                    let upper_curve: U = self.upper_bound + self.edge_falloff;
+                    let alpha = interp::s_curve3((control_value - lower_curve) /
+                                                 (upper_curve - lower_curve));
+
+                    interp::linear(self.source2.get(point), self.source1.get(point), alpha)
+                },
+                _ => self.source1.get(point),
+            }
+        } else {
+            if control_value < self.lower_bound || control_value > self.upper_bound {
+                self.source1.get(point)
+            } else {
+                self.source2.get(point)
+            }
+        }
+    }
+}

--- a/src/modules/selectors/select.rs
+++ b/src/modules/selectors/select.rs
@@ -14,7 +14,7 @@
 
 use num_traits::Float;
 use math::interp;
-use Module;
+use NoiseModule;
 
 /// Noise module that outputs the value selected from one of two source
 /// modules chosen by the output value from a control module.
@@ -61,10 +61,10 @@ impl<Source1, Source2, Control, T> Select<Source1, Source2, Control, T> {
     }
 }
 
-impl<Source1, Source2, Control, T, U> Module<T> for Select<Source1, Source2, Control, U>
-    where Source1: Module<T, Output = U>,
-          Source2: Module<T, Output = U>,
-          Control: Module<T, Output = U>,
+impl<Source1, Source2, Control, T, U> NoiseModule<T> for Select<Source1, Source2, Control, U>
+    where Source1: NoiseModule<T, Output = U>,
+          Source2: NoiseModule<T, Output = U>,
+          Control: NoiseModule<T, Output = U>,
           T: Copy,
           U: Float,
 {

--- a/src/permutationtable.rs
+++ b/src/permutationtable.rs
@@ -26,7 +26,7 @@ const TABLE_SIZE: usize = 256;
 ///
 /// Table creation is expensive, so in most circumstances you'll only want to
 /// create one of these per generator.
-#[allow(missing_copy_implementations)]
+#[derive(Copy)]
 pub struct PermutationTable {
     values: [u8; TABLE_SIZE],
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -13,21 +13,8 @@
 // limitations under the License.
 
 use num_traits::Float;
-
+use math::interp;
 use {PermutationTable, math};
-
-/// Linearly interpolate values.
-fn lerp<T: Float>(a: T, b: T, x: T) -> T {
-    a + x * (b - a)
-}
-
-/// Map value between `0.0` and `1.0` to a Quintic Hermite curve.
-fn smoothstep<T: Float>(x: T) -> T {
-    let _15: T = math::cast(15.0);
-    let _10: T = math::cast(10.0);
-    let _6: T = math::cast(6.0);
-    x * x * x * (x * (x * _6 - _15) + _10)
-}
 
 /// 2-dimensional value noise
 #[cfg_attr(rustfmt, rustfmt_skip)]
@@ -40,16 +27,16 @@ pub fn value2<T: Float>(perm_table: &PermutationTable, point: &math::Point2<T>) 
     let floored = math::map2(*point, T::floor);
     let near_corner = math::map2(floored, math::cast);
     let far_corner = math::add2(near_corner, math::one2());
-    let weight = math::map2(math::sub2(*point, floored), smoothstep);
+    let weight = math::map2(math::sub2(*point, floored), interp::s_curve5);
 
     let f00 = get(perm_table, [near_corner[0], near_corner[1]]);
     let f10 = get(perm_table, [far_corner[0], near_corner[1]]);
     let f01 = get(perm_table, [near_corner[0], far_corner[1]]);
     let f11 = get(perm_table, [far_corner[0], far_corner[1]]);
 
-    let d0 = lerp(f00, f10, weight[0]);
-    let d1 = lerp(f01, f11, weight[0]);
-    let d = lerp(d0, d1, weight[1]);
+    let d0 = interp::linear(f00, f10, weight[0]);
+    let d1 = interp::linear(f01, f11, weight[0]);
+    let d = interp::linear(d0, d1, weight[1]);
 
     d * math::cast(2) - math::cast(1)
 }
@@ -65,7 +52,7 @@ pub fn value3<T: Float>(perm_table: &PermutationTable, point: &math::Point3<T>) 
     let floored = math::map3(*point, T::floor);
     let near_corner = math::map3(floored, math::cast);
     let far_corner = math::add3(near_corner, math::one3());
-    let weight = math::map3(math::sub3(*point, floored), smoothstep);
+    let weight = math::map3(math::sub3(*point, floored), interp::s_curve5);
 
     let f000: T = get(perm_table, [near_corner[0], near_corner[1], near_corner[2]]);
     let f100: T = get(perm_table, [far_corner[0], near_corner[1], near_corner[2]]);
@@ -76,13 +63,13 @@ pub fn value3<T: Float>(perm_table: &PermutationTable, point: &math::Point3<T>) 
     let f011: T = get(perm_table, [near_corner[0], far_corner[1], far_corner[2]]);
     let f111: T = get(perm_table, [far_corner[0], far_corner[1], far_corner[2]]);
 
-    let d00 = lerp(f000, f100, weight[0]);
-    let d01 = lerp(f001, f101, weight[0]);
-    let d10 = lerp(f010, f110, weight[0]);
-    let d11 = lerp(f011, f111, weight[0]);
-    let d0 = lerp(d00, d10, weight[1]);
-    let d1 = lerp(d01, d11, weight[1]);
-    let d = lerp(d0, d1, weight[2]);
+    let d00 = interp::linear(f000, f100, weight[0]);
+    let d01 = interp::linear(f001, f101, weight[0]);
+    let d10 = interp::linear(f010, f110, weight[0]);
+    let d11 = interp::linear(f011, f111, weight[0]);
+    let d0 = interp::linear(d00, d10, weight[1]);
+    let d1 = interp::linear(d01, d11, weight[1]);
+    let d = interp::linear(d0, d1, weight[2]);
 
     d * math::cast(2) - math::cast(1)
 }
@@ -98,7 +85,7 @@ pub fn value4<T: Float>(perm_table: &PermutationTable, point: &math::Point4<T>) 
     let floored = math::map4(*point, T::floor);
     let near_corner = math::map4(floored, math::cast);
     let far_corner = math::add4(near_corner, math::one4());
-    let weight = math::map4(math::sub4(*point, floored), smoothstep);
+    let weight = math::map4(math::sub4(*point, floored), interp::s_curve5);
 
     let f0000: T = get(perm_table, [near_corner[0], near_corner[1], near_corner[2], near_corner[3]]);
     let f1000: T = get(perm_table, [far_corner[0], near_corner[1], near_corner[2], near_corner[3]]);
@@ -117,21 +104,21 @@ pub fn value4<T: Float>(perm_table: &PermutationTable, point: &math::Point4<T>) 
     let f0111: T = get(perm_table, [near_corner[0], far_corner[1], far_corner[2], far_corner[3]]);
     let f1111: T = get(perm_table, [far_corner[0], far_corner[1], far_corner[2], far_corner[3]]);
 
-    let d000 = lerp(f0000, f1000, weight[0]);
-    let d010 = lerp(f0010, f1010, weight[0]);
-    let d100 = lerp(f0100, f1100, weight[0]);
-    let d110 = lerp(f0110, f1110, weight[0]);
-    let d001 = lerp(f0001, f1001, weight[0]);
-    let d011 = lerp(f0011, f1011, weight[0]);
-    let d101 = lerp(f0101, f1101, weight[0]);
-    let d111 = lerp(f0111, f1111, weight[0]);
-    let d00 = lerp(d000, d100, weight[1]);
-    let d10 = lerp(d010, d110, weight[1]);
-    let d01 = lerp(d001, d101, weight[1]);
-    let d11 = lerp(d011, d111, weight[1]);
-    let d0 = lerp(d00, d10, weight[2]);
-    let d1 = lerp(d01, d11, weight[2]);
-    let d = lerp(d0, d1, weight[3]);
+    let d000 = interp::linear(f0000, f1000, weight[0]);
+    let d010 = interp::linear(f0010, f1010, weight[0]);
+    let d100 = interp::linear(f0100, f1100, weight[0]);
+    let d110 = interp::linear(f0110, f1110, weight[0]);
+    let d001 = interp::linear(f0001, f1001, weight[0]);
+    let d011 = interp::linear(f0011, f1011, weight[0]);
+    let d101 = interp::linear(f0101, f1101, weight[0]);
+    let d111 = interp::linear(f0111, f1111, weight[0]);
+    let d00 = interp::linear(d000, d100, weight[1]);
+    let d10 = interp::linear(d010, d110, weight[1]);
+    let d01 = interp::linear(d001, d101, weight[1]);
+    let d11 = interp::linear(d011, d111, weight[1]);
+    let d0 = interp::linear(d00, d10, weight[2]);
+    let d1 = interp::linear(d01, d11, weight[2]);
+    let d = interp::linear(d0, d1, weight[3]);
 
     d * math::cast(2) - math::cast(1)
 }


### PR DESCRIPTION
Opening this WIP PR so I can get feedback on the implementation as I work on it.

Reference Issue: #100 

Currently, I've only added the Checkerboard and Constant Generator modules while I worked out the type system and implementation. It ended up similar to Aatch's ValueSourceN trait, without the N portion as I pass that though the function implementation instead. I have not figured out how to implement Aatch's ValueSource with associated Input and Output types yet. Hints would be helpful, since this would make it much simpler to implement dimension-agnostic modules like Select or Constant, as Aatch proposed.

My intention is to give every generator/modifier/mutator the Module trait, thereby allowing composition through the use of Modules.

The foundation of all the modules I plan to implement is based on libnoise.

For a minimal implementation, I'll add the following modules:
- [x] Checkerboard
- [x] Constant
- [x] Cylinders
- [x] Perlin
- [x] Select

Modules to be included in later PRs:
Simple Generators:
- OpenSimplex
- Simplex (2D only, 3D and up is covered by patent)
- Spheres
- Voronoi

Fractal Generators:
- Billow
- Multifractal
- Ridged Multifractal

Combiners:
- Add
- Max
- Min
- Multiply
- Power

Modifier Modules:
- Abs
- Clamp
- Curve
- Exponent
- Invert
- ScaleBias
- Terrace

Selector Modules:
- Blend

Transformer Modules:
- Displace
- RotatePoint
- ScalePoint
- TransformPoint
- Turbulence

Miscellaneous Modules:
- Cache

I'm open to other module suggestions, as well. There's probably a bunch more that'd fit under Fractal Generators, since there's a lot of ways to combine perlin noise in octaves.