### PR TITLE
Added value noise

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,9 @@ name = "cell_manhattan_inv"
 [[example]]
 name = "cell_manhattan_value"
 
+[[example]]
+name = "value"
+
 [[bench]]
 name = "benches"
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,19 @@ A slower but higher quality form of gradient noise:
 - `open_simplex2`
 - `open_simplex3`
 
+### Value Noise
+
+Value noise (sometimes mistaken with gradient noise) produces lower quality
+smooth noise. It exhibits pronounced grid artifacts, but can be slightly faster
+than gradient noise. Benchmarks show it's about 1.2–1.3× faster than Perlin noise.
+
+Cell neighbours are blended using a weighted S-curve linear interpolation
+method. This removes any discontinuities across grid edges.
+
+- `value2`
+- `value3`
+- `value4`
+
 ### Fractional Brownian Motion
 
 A way of combining multiple octaves of a noise function to create a richer and

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -22,6 +22,7 @@ extern crate test;
 use noise::Seed;
 use noise::{perlin2, perlin3, perlin4};
 use noise::{open_simplex2, open_simplex3};
+use noise::{value2, value3, value4};
 use noise::{cell2_range, cell3_range, cell4_range};
 use noise::{cell2_range_inv, cell3_range_inv, cell4_range_inv};
 use noise::{cell2_value, cell3_value, cell4_value};
@@ -58,6 +59,24 @@ fn bench_open_simplex2(bencher: &mut Bencher) {
 fn bench_open_simplex3(bencher: &mut Bencher) {
     let seed = Seed::new(0);
     bencher.iter(|| open_simplex3(black_box(&seed), black_box(&[42.0f64, 37.0, 26.0])));
+}
+
+#[bench]
+fn bench_value2(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| value2(black_box(&seed), black_box(&[42.0f64, 37.0])));
+}
+
+#[bench]
+fn bench_value3(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| value3(black_box(&seed), black_box(&[42.0f64, 37.0, 26.0])));
+}
+
+#[bench]
+fn bench_value4(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| value4(black_box(&seed), black_box(&[42.0f64, 37.0, 26.0, 128.0])));
 }
 
 #[bench]
@@ -223,6 +242,42 @@ fn bench_open_simplex3_64x64(bencher: &mut Bencher) {
         for y in 0..64 {
             for x in 0..64 {
                 black_box(open_simplex3(black_box(&seed), &[x as f64, y as f64, x as f64]));
+            }
+        }
+    });
+}
+
+#[bench]
+fn bench_value2_64x64(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| {
+        for y in 0..64 {
+            for x in 0..64 {
+                black_box(value2(black_box(&seed), &[x as f64, y as f64]));
+            }
+        }
+    });
+}
+
+#[bench]
+fn bench_value3_64x64(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| {
+        for y in 0..64 {
+            for x in 0..64 {
+                black_box(value3(black_box(&seed), &[x as f64, y as f64, x as f64]));
+            }
+        }
+    });
+}
+
+#[bench]
+fn bench_value4_64x64(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| {
+        for y in 0..64 {
+            for x in 0..64 {
+                black_box(value4(black_box(&seed), &[x as f64, y as f64, x as f64, y as f64]));
             }
         }
     });

--- a/examples/value.rs
+++ b/examples/value.rs
@@ -1,0 +1,40 @@
+// Copyright 2015 The Noise-rs Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! An example of using value noise
+
+extern crate noise;
+
+use noise::{value2, value3, value4, Seed, Point2};
+
+mod debug;
+
+fn main() {
+    debug::render_png("value2.png", &Seed::new(0), 1024, 1024, scaled_value2);
+    debug::render_png("value3.png", &Seed::new(0), 1024, 1024, scaled_value3);
+    debug::render_png("value4.png", &Seed::new(0), 1024, 1024, scaled_value4);
+    println!("\nGenerated value2.png, value3.png and value4.png");
+}
+
+fn scaled_value2(seed: &Seed, point: &Point2<f64>) -> f64 {
+    value2(seed, &[point[0] / 16.0, point[1] / 16.0])
+}
+
+fn scaled_value3(seed: &Seed, point: &Point2<f64>) -> f64 {
+    value3(seed, &[point[0] / 16.0, point[1] / 16.0, point[0] / 32.0])
+}
+
+fn scaled_value4(seed: &Seed, point: &Point2<f64>) -> f64 {
+    value4(seed, &[point[0] / 16.0, point[1] / 16.0, point[0] / 32.0, point[1] / 32.0])
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ extern crate rand;
 pub use seed::Seed;
 pub use math::{Point2, Point3, Point4};
 pub use perlin::{perlin2, perlin3, perlin4};
+pub use value::{value2, value3, value4};
 pub use open_simplex::{open_simplex2, open_simplex3};
 pub use brownian::{Brownian2, Brownian3, Brownian4};
 
@@ -50,6 +51,7 @@ mod seed;
 
 mod brownian;
 mod perlin;
+mod value;
 mod open_simplex;
 mod cell;
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -21,11 +21,12 @@ fn lerp<T: Float>(a: T, b: T, x: T) -> T {
     a + x * (b - a)
 }
 
-/// Map value between `0.0` and `1.0` to a Cubic Hermite curve.
+/// Map value between `0.0` and `1.0` to a Quintic Hermite curve.
 fn smoothstep<T: Float>(x: T) -> T {
-    let _3: T = math::cast(3.0);
-    let _2: T = math::cast(2.0);
-    x * x * (_3 - _2 * x)
+    let _15: T = math::cast(15.0);
+    let _10: T = math::cast(10.0);
+    let _6: T = math::cast(6.0);
+    x * x * x * (x * (x * _6 - _15) + _10)
 }
 
 /// 2-dimensional value noise

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,0 +1,133 @@
+// Copyright 2015 The Noise-rs Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use num::Float;
+
+use {math, Seed};
+
+/// Linearly interpolate values.
+fn lerp<T: Float>(a: T, b: T, x: T) -> T {
+    a + x * (b - a)
+}
+
+/// Map value between `0.0` and `1.0` to a Cubic Hermite curve.
+fn smoothstep<T: Float>(x: T) -> T {
+    let _3: T = math::cast(3.0);
+    let _2: T = math::cast(2.0);
+    x * x * (_3 - _2 * x)
+}
+
+/// 2-dimensional value noise
+pub fn value2<T: Float>(seed: &Seed, point: &math::Point2<T>) -> T {
+    #[inline(always)]
+    fn get<T: Float>(seed: &Seed, corner: math::Point2<isize>) -> T {
+        math::cast::<_, T>(seed.get2(corner)) * math::cast(1.0 / 255.0)
+    }
+
+    let floored = math::map2(*point, Float::floor);
+    let near_corner = math::map2(floored, math::cast);
+    let far_corner = math::add2(near_corner, math::one2());
+    let weight = math::map2(math::sub2(*point, floored), smoothstep);
+
+    let f00 = get(seed, [near_corner[0], near_corner[1]]);
+    let f10 = get(seed, [far_corner[0], near_corner[1]]);
+    let f01 = get(seed, [near_corner[0], far_corner[1]]);
+    let f11 = get(seed, [far_corner[0], far_corner[1]]);
+
+    let d0 = lerp(f00, f10, weight[0]);
+    let d1 = lerp(f01, f11, weight[0]);
+    let d = lerp(d0, d1, weight[1]);
+
+    d * math::cast(2) - math::cast(1)
+}
+
+// 3-dimensional value noise
+pub fn value3<T: Float>(seed: &Seed, point: &math::Point3<T>) -> T {
+    #[inline(always)]
+    fn get<T: Float>(seed: &Seed, corner: math::Point3<isize>) -> T {
+        math::cast::<_, T>(seed.get3(corner)) * math::cast(1.0 / 255.0)
+    }
+
+    let floored = math::map3(*point, Float::floor);
+    let near_corner = math::map3(floored, math::cast);
+    let far_corner = math::add3(near_corner, math::one3());
+    let weight = math::map3(math::sub3(*point, floored), smoothstep);
+
+    let f000: T = get(seed, [near_corner[0], near_corner[1], near_corner[2]]);
+    let f100: T = get(seed, [far_corner[0], near_corner[1], near_corner[2]]);
+    let f010: T = get(seed, [near_corner[0], far_corner[1], near_corner[2]]);
+    let f110: T = get(seed, [far_corner[0], far_corner[1], near_corner[2]]);
+    let f001: T = get(seed, [near_corner[0], near_corner[1], far_corner[2]]);
+    let f101: T = get(seed, [far_corner[0], near_corner[1], far_corner[2]]);
+    let f011: T = get(seed, [near_corner[0], far_corner[1], far_corner[2]]);
+    let f111: T = get(seed, [far_corner[0], far_corner[1], far_corner[2]]);
+
+    let d00 = lerp(f000, f100, weight[0]);
+    let d01 = lerp(f001, f101, weight[0]);
+    let d10 = lerp(f010, f110, weight[0]);
+    let d11 = lerp(f011, f111, weight[0]);
+    let d0 = lerp(d00, d10, weight[1]);
+    let d1 = lerp(d01, d11, weight[1]);
+    let d = lerp(d0, d1, weight[2]);
+
+    d * math::cast(2) - math::cast(1)
+}
+
+// 4-dimensional value noise
+pub fn value4<T: Float>(seed: &Seed, point: &math::Point4<T>) -> T {
+    #[inline(always)]
+    fn get<T: Float>(seed: &Seed, corner: math::Point4<isize>) -> T {
+        math::cast::<_, T>(seed.get4(corner)) * math::cast(1.0 / 255.0)
+    }
+
+    let floored = math::map4(*point, Float::floor);
+    let near_corner = math::map4(floored, math::cast);
+    let far_corner = math::add4(near_corner, math::one4());
+    let weight = math::map4(math::sub4(*point, floored), smoothstep);
+
+    let f0000: T = get(seed, [near_corner[0], near_corner[1], near_corner[2], near_corner[3]]);
+    let f1000: T = get(seed, [far_corner[0], near_corner[1], near_corner[2], near_corner[3]]);
+    let f0100: T = get(seed, [near_corner[0], far_corner[1], near_corner[2], near_corner[3]]);
+    let f1100: T = get(seed, [far_corner[0], far_corner[1], near_corner[2], near_corner[3]]);
+    let f0010: T = get(seed, [near_corner[0], near_corner[1], far_corner[2], near_corner[3]]);
+    let f1010: T = get(seed, [far_corner[0], near_corner[1], far_corner[2], near_corner[3]]);
+    let f0110: T = get(seed, [near_corner[0], far_corner[1], far_corner[2], near_corner[3]]);
+    let f1110: T = get(seed, [far_corner[0], far_corner[1], far_corner[2], near_corner[3]]);
+    let f0001: T = get(seed, [near_corner[0], near_corner[1], near_corner[2], far_corner[3]]);
+    let f1001: T = get(seed, [far_corner[0], near_corner[1], near_corner[2], far_corner[3]]);
+    let f0101: T = get(seed, [near_corner[0], far_corner[1], near_corner[2], far_corner[3]]);
+    let f1101: T = get(seed, [far_corner[0], far_corner[1], near_corner[2], far_corner[3]]);
+    let f0011: T = get(seed, [near_corner[0], near_corner[1], far_corner[2], far_corner[3]]);
+    let f1011: T = get(seed, [far_corner[0], near_corner[1], far_corner[2], far_corner[3]]);
+    let f0111: T = get(seed, [near_corner[0], far_corner[1], far_corner[2], far_corner[3]]);
+    let f1111: T = get(seed, [far_corner[0], far_corner[1], far_corner[2], far_corner[3]]);
+
+    let d000 = lerp(f0000, f1000, weight[0]);
+    let d010 = lerp(f0010, f1010, weight[0]);
+    let d100 = lerp(f0100, f1100, weight[0]);
+    let d110 = lerp(f0110, f1110, weight[0]);
+    let d001 = lerp(f0001, f1001, weight[0]);
+    let d011 = lerp(f0011, f1011, weight[0]);
+    let d101 = lerp(f0101, f1101, weight[0]);
+    let d111 = lerp(f0111, f1111, weight[0]);
+    let d00 = lerp(d000, d100, weight[1]);
+    let d10 = lerp(d010, d110, weight[1]);
+    let d01 = lerp(d001, d101, weight[1]);
+    let d11 = lerp(d011, d111, weight[1]);
+    let d0 = lerp(d00, d10, weight[2]);
+    let d1 = lerp(d01, d11, weight[2]);
+    let d = lerp(d0, d1, weight[3]);
+
+    d * math::cast(2) - math::cast(1)
+}

--- a/src/value.rs
+++ b/src/value.rs
@@ -52,7 +52,7 @@ pub fn value2<T: Float>(seed: &Seed, point: &math::Point2<T>) -> T {
     d * math::cast(2) - math::cast(1)
 }
 
-// 3-dimensional value noise
+/// 3-dimensional value noise
 pub fn value3<T: Float>(seed: &Seed, point: &math::Point3<T>) -> T {
     #[inline(always)]
     fn get<T: Float>(seed: &Seed, corner: math::Point3<isize>) -> T {
@@ -84,7 +84,7 @@ pub fn value3<T: Float>(seed: &Seed, point: &math::Point3<T>) -> T {
     d * math::cast(2) - math::cast(1)
 }
 
-// 4-dimensional value noise
+/// 4-dimensional value noise
 pub fn value4<T: Float>(seed: &Seed, point: &math::Point4<T>) -> T {
     #[inline(always)]
     fn get<T: Float>(seed: &Seed, corner: math::Point4<isize>) -> T {


### PR DESCRIPTION
Added value noise + benchmarks, tests, and additions to README.

Uses 5th-order smoothstep for blending.

Resolves #106.

## Images

2D:

![value2](https://cloud.githubusercontent.com/assets/9031092/16362539/d37d07e6-3be3-11e6-8a94-684442e87431.png)

3D:

![value3](https://cloud.githubusercontent.com/assets/9031092/16362540/d5c3b28e-3be3-11e6-9a87-ca2fa8ea4ba4.png)

4D:

![value4](https://cloud.githubusercontent.com/assets/9031092/16362541/d9ace6ea-3be3-11e6-90b5-48c44a2e6d5c.png)


## Comparison with Cell value noise

Open the 2D value noise image and this image in new tabs, and toggle between them.

![cell2_value](https://cloud.githubusercontent.com/assets/9031092/16361925/fe2c4040-3bd1-11e6-83a0-c35f29a1a5c0.png)

## Benchmarks

![ss 2016-06-26 at 07 15 50](https://cloud.githubusercontent.com/assets/9031092/16361937/6fcb8c92-3bd2-11e6-9832-d7c344d19411.png)
