### PR TITLE
Fix Brownian noise values accumulating at origin.

### DIFF
--- a/src/brownian.rs
+++ b/src/brownian.rs
@@ -205,11 +205,18 @@ macro_rules! impl_brownian {
             /// Apply the Brownian noise function for the supplied seed and point.
             #[inline]
             pub fn apply(&self, seed: &Seed, point: &$Point<T>) -> T {
+                // Fixes weird accumulation at the origin.
+                //
+                // The chosen offset is the square root of 3. An irrational
+                // number is chosen so grid-aligned noise values don't coincide
+                // with each other.
+                const OFFSET: f64 = 1.73205080756887;
+
                 let mut frequency: T = self.frequency;
                 let mut amplitude: T = math::cast(1);
                 let mut total_amplitude = T::zero();
                 let mut result: T = math::cast(0);
-                let mut offset: T = math::cast(1.73205080756887);
+                let mut offset: T = math::cast(OFFSET);
                 let point = *point;
                 for _ in 0..self.octaves {
                     let scaled_point = $mapn(point, |v| v * frequency + offset);
@@ -217,7 +224,7 @@ macro_rules! impl_brownian {
                     total_amplitude = total_amplitude + amplitude;
                     amplitude = amplitude * self.persistence;
                     frequency = frequency * self.lacunarity;
-                    offset = offset + math::cast(1.73205080756887);
+                    offset = offset + math::cast(OFFSET);
                 }
                 result / total_amplitude
             }

--- a/src/brownian.rs
+++ b/src/brownian.rs
@@ -209,13 +209,15 @@ macro_rules! impl_brownian {
                 let mut amplitude: T = math::cast(1);
                 let mut total_amplitude = T::zero();
                 let mut result: T = math::cast(0);
+                let mut offset: T = math::cast(1.73205080756887);
                 let point = *point;
                 for _ in 0..self.octaves {
-                    let scaled_point = $mapn(point, |v| v * frequency);
+                    let scaled_point = $mapn(point, |v| v * frequency + offset);
                     result = result + ((self.function)(seed, &scaled_point) * amplitude);
                     total_amplitude = total_amplitude + amplitude;
                     amplitude = amplitude * self.persistence;
                     frequency = frequency * self.lacunarity;
+                    offset = offset + math::cast(1.73205080756887);
                 }
                 result / total_amplitude
             }


### PR DESCRIPTION
Offset the noise coordinates on each octave.

Fixes weird accumulation going on when noise coordinate is zero.

The chosen offset is the square root of 3. An irrational number is chosen so grid-aligned noise values won't coincide with each other. Pretty much arbitrary.

Comparison:

**Before:**

![brownian3](https://cloud.githubusercontent.com/assets/9031092/16362999/4cb73270-3bef-11e6-8c0a-a0aa82062dd3.png)

**After:**

![brownian3 - copy](https://cloud.githubusercontent.com/assets/9031092/16363002/56cfba8e-3bef-11e6-9d8e-0eaa17bc8c46.png)