### PR TITLE
Optimize OpenSimplex 2D and 3D

### DIFF
--- a/src/open_simplex.rs
+++ b/src/open_simplex.rs
@@ -165,7 +165,6 @@ pub fn open_simplex3<T: Float>(seed: &Seed, point: &::Point3<T>) -> T {
     let mut dz0 = point[2] - zb;
 
     let mut value = zero;
-    let c0 = one + two * squish_constant;
 
     if frac_sum <= one {
         // We're inside the tetrahedron (3-Simplex) at (0, 0, 0)
@@ -192,6 +191,7 @@ pub fn open_simplex3<T: Float>(seed: &Seed, point: &::Point3<T>) -> T {
         value = value + gradient(seed, xsb, ysb, zsb + one, dx3, dy3, dz3);
     } else if frac_sum >= two {
         // We're inside the tetrahedron (3-Simplex) at (1, 1, 1)
+        let c0 = one + two * squish_constant;
 
         // Contribution at (1, 1, 0)
         let dx3 = dx0 - c0;
@@ -238,8 +238,8 @@ pub fn open_simplex3<T: Float>(seed: &Seed, point: &::Point3<T>) -> T {
         value = value + gradient(seed, xsb, ysb, zsb + one, dx3, dy3, dz3);
 
         // Contribution at (1, 1, 0)
-        let dx4 = dx0 - c0;
-        let dy4 = dy0 - c0;
+        let dx4 = dx1 - squish_constant;
+        let dy4 = dy2 - squish_constant;
         let dz4 = dz1 - squish_constant;
         value = value + gradient(seed, xsb + one, ysb + one, zsb, dx4, dy4, dz4);
 

--- a/src/open_simplex.rs
+++ b/src/open_simplex.rs
@@ -195,10 +195,9 @@ pub fn open_simplex3<T: Float>(seed: &Seed, point: &::Point3<T>) -> T {
         value = value + gradient(seed, xsb, ysb + one, zsb + one, dx1, dy1, dz1);
 
         //Contribution (1,1,1)
-        let c1 = c0 + squish_constant;
-        dx0 = dx0 - c1;
-        dy0 = dy0 - c1;
-        dz0 = dz0 - c1;
+        dx0 = dx3 - squish_constant;
+        dy0 = dy3 - squish_constant;
+        dz0 = dz2 - squish_constant;
         value = value + gradient(seed, xsb + one, ysb + one, zsb + one, dx0, dy0, dz0);
     } else { //We're inside the octahedron (Rectified 3-Simplex) in between.
         //Contribution (1,0,0)
@@ -222,7 +221,7 @@ pub fn open_simplex3<T: Float>(seed: &Seed, point: &::Point3<T>) -> T {
         //Contribution (1,1,0)
         let dx4 = dx0 - c0;
         let dy4 = dy0 - c0;
-        let dz4 = dz0 - c0 + one;
+        let dz4 = dz1 - squish_constant;
         value = value + gradient(seed, xsb + one, ysb + one, zsb, dx4, dy4, dz4);
 
         //Contribution (1,0,1)

--- a/src/open_simplex.rs
+++ b/src/open_simplex.rs
@@ -80,12 +80,12 @@ pub fn open_simplex2<T: Float>(seed: &Seed, point: &::Point2<T>) -> T {
     //Contribution (1,0)
     let dx1 = dx0 - one - squish_constant;
     let dy1 = dy0 - zero - squish_constant;
-    value = value + gradient(seed, xs_floor + one, ys_floor + zero, dx1, dy1);
+    value = value + gradient(seed, xs_floor + one, ys_floor, dx1, dy1);
 
     //Contribution (0,1)
     let dx2 = dx1 + one;
     let dy2 = dy1 - one;
-    value = value + gradient(seed, xs_floor + zero, ys_floor + one, dx2, dy2);
+    value = value + gradient(seed, xs_floor, ys_floor + one, dx2, dy2);
 
     if frac_sum > one {
         xs_floor = xs_floor + one;
@@ -155,19 +155,22 @@ pub fn open_simplex3<T: Float>(seed: &Seed, point: &::Point3<T>) -> T {
     let mut dz0 = point[2] - zb;
 
     let mut value = zero;
+    let c0 = one + two * squish_constant;
+    // let c1 = one - squish_constant;
+
     if in_sum <= one { //We're inside the tetrahedron (3-Simplex) at (0,0,0)
         //Contribution (0,0,0)
         value = value + gradient(seed, xsb, ysb, zsb, dx0, dy0, dz0);
 
         //Contribution (1,0,0)
         let dx1 = dx0 - one - squish_constant;
-        let dy1 = dy0 - zero - squish_constant;
-        let dz1 = dz0 - zero - squish_constant;
+        let dy1 = dy0 - squish_constant;
+        let dz1 = dz0 - squish_constant;
         value = value + gradient(seed, xsb + one, ysb, zsb, dx1, dy1, dz1);
 
         //Contribution (0,1,0)
-        let dx2 = dx0 - zero - squish_constant;
-        let dy2 = dy0 - one - squish_constant;
+        let dx2 = dx1 + one;
+        let dy2 = dy1 - one;
         let dz2 = dz1;
         value = value + gradient(seed, xsb, ysb + one, zsb, dx2, dy2, dz2);
 
@@ -178,19 +181,19 @@ pub fn open_simplex3<T: Float>(seed: &Seed, point: &::Point3<T>) -> T {
         value = value + gradient(seed, xsb, ysb, zsb + one, dx3, dy3, dz3);
     } else if in_sum >= two { //We're inside the tetrahedron (3-Simplex) at (1,11)
         //Contribution (1,1,0)
-        let dx3 = dx0 - one - two * squish_constant;
-        let dy3 = dy0 - one - two * squish_constant;
-        let dz3 = dz0 - zero - two * squish_constant;
+        let dx3 = dx0 - c0;
+        let dy3 = dy0 - c0;
+        let dz3 = dz0 - c0 + one;
         value = value + gradient(seed, xsb + one, ysb + one, zsb, dx3, dy3, dz3);
 
         //Contribution (1,0,1)
         let dx2 = dx3;
-        let dy2 = dy0 - zero - two * squish_constant;
-        let dz2 = dz0 - one - two * squish_constant;
+        let dy2 = dy3 + one;
+        let dz2 = dz3 - one;
         value = value + gradient(seed, xsb + one, ysb, zsb + one, dx2, dy2, dz2);
 
         //Contribution (0,1,1)
-        let dx1 = dx0 - zero - two * squish_constant;
+        let dx1 = dx3 + one;
         let dy1 = dy3;
         let dz1 = dz2;
         value = value + gradient(seed, xsb, ysb + one, zsb + one, dx1, dy1, dz1);
@@ -208,8 +211,8 @@ pub fn open_simplex3<T: Float>(seed: &Seed, point: &::Point3<T>) -> T {
         value = value + gradient(seed, xsb + one, ysb, zsb, dx1, dy1, dz1);
 
         //Contribution (0,1,0)
-        let dx2 = dx0 - zero - squish_constant;
-        let dy2 = dy0 - one - squish_constant;
+        let dx2 = dx1 + one;
+        let dy2 = dy1 - one;
         let dz2 = dz1;
         value = value + gradient(seed, xsb, ysb + one, zsb, dx2, dy2, dz2);
 
@@ -220,19 +223,19 @@ pub fn open_simplex3<T: Float>(seed: &Seed, point: &::Point3<T>) -> T {
         value = value + gradient(seed, xsb, ysb, zsb + one, dx3, dy3, dz3);
 
         //Contribution (1,1,0)
-        let dx4 = dx0 - one - two * squish_constant;
-        let dy4 = dy0 - one - two * squish_constant;
-        let dz4 = dz0 - zero - two * squish_constant;
+        let dx4 = dx0 - c0;
+        let dy4 = dy0 - c0;
+        let dz4 = dz0 - c0 + one;
         value = value + gradient(seed, xsb + one, ysb + one, zsb, dx4, dy4, dz4);
 
         //Contribution (1,0,1)
         let dx5 = dx4;
-        let dy5 = dy0 - zero - two * squish_constant;
-        let dz5 = dz0 - one - two * squish_constant;
+        let dy5 = dy4 + one;
+        let dz5 = dz4 - one;
         value = value + gradient(seed, xsb + one, ysb, zsb + one, dx5, dy5, dz5);
 
         //Contribution (0,1,1)
-        let dx6 = dx0 - zero - two * squish_constant;
+        let dx6 = dx5 + one;
         let dy6 = dy4;
         let dz6 = dz5;
         value = value + gradient(seed, xsb, ysb + one, zsb + one, dx6, dy6, dz6);

--- a/src/open_simplex.rs
+++ b/src/open_simplex.rs
@@ -47,7 +47,6 @@ pub fn open_simplex2<T: Float>(seed: &Seed, point: &::Point2<T>) -> T {
 
     let zero: T = math::cast(0);
     let one: T = math::cast(1);
-    let two: T = math::cast(2);
     let squish_constant: T = math::cast(SQUISH_CONSTANT_2D);
 
     //Place input coordinates onto grid.
@@ -79,20 +78,19 @@ pub fn open_simplex2<T: Float>(seed: &Seed, point: &::Point2<T>) -> T {
 
     //Contribution (1,0)
     let dx1 = dx0 - one - squish_constant;
-    let dy1 = dy0 - zero - squish_constant;
+    let dy1 = dy0 - squish_constant;
     value = value + gradient(seed, xs_floor + one, ys_floor, dx1, dy1);
 
     //Contribution (0,1)
-    let dx2 = dx1 + one;
+    let dx2 = dx0 - squish_constant;
     let dy2 = dy1 - one;
     value = value + gradient(seed, xs_floor, ys_floor + one, dx2, dy2);
 
     if frac_sum > one {
         xs_floor = xs_floor + one;
         ys_floor = ys_floor + one;
-        let t = one + two * squish_constant;
-        dx0 = dx0 - t;
-        dy0 = dy0 - t;
+        dx0 = dx1 - squish_constant;
+        dy0 = dy2 - squish_constant;
     }
 
     //Contribution (0,0) or (1,1)
@@ -167,7 +165,7 @@ pub fn open_simplex3<T: Float>(seed: &Seed, point: &::Point3<T>) -> T {
         value = value + gradient(seed, xsb + one, ysb, zsb, dx1, dy1, dz1);
 
         //Contribution (0,1,0)
-        let dx2 = dx1 + one;
+        let dx2 = dx0 - squish_constant;
         let dy2 = dy1 - one;
         let dz2 = dz1;
         value = value + gradient(seed, xsb, ysb + one, zsb, dx2, dy2, dz2);
@@ -175,7 +173,7 @@ pub fn open_simplex3<T: Float>(seed: &Seed, point: &::Point3<T>) -> T {
         //Contribution (0,0,1)
         let dx3 = dx2;
         let dy3 = dy1;
-        let dz3 = dz0 - one - squish_constant;
+        let dz3 = dz1 - one;
         value = value + gradient(seed, xsb, ysb, zsb + one, dx3, dy3, dz3);
     } else if in_sum >= two { //We're inside the tetrahedron (3-Simplex) at (1,11)
         //Contribution (1,1,0)
@@ -234,7 +232,7 @@ pub fn open_simplex3<T: Float>(seed: &Seed, point: &::Point3<T>) -> T {
         value = value + gradient(seed, xsb + one, ysb, zsb + one, dx5, dy5, dz5);
 
         //Contribution (0,1,1)
-        let dx6 = dx5 + one;
+        let dx6 = dx4 + one;
         let dy6 = dy4;
         let dz6 = dz5;
         value = value + gradient(seed, xsb, ysb + one, zsb + one, dx6, dy6, dz6);

--- a/src/open_simplex.rs
+++ b/src/open_simplex.rs
@@ -82,12 +82,12 @@ pub fn open_simplex2<T: Float>(seed: &Seed, point: &::Point2<T>) -> T {
     // |     /     B   |
     // (0, 1) --- (1, 1)
 
-    // Point (1, 0)
+    // Contribution (1, 0)
     let dx1 = dx0 - one - squish_constant;
     let dy1 = dy0 - squish_constant;
     value = value + gradient(seed, xs_floor + one, ys_floor, dx1, dy1);
 
-    // Point (0, 1)
+    // Contribution (0, 1)
     let dx2 = dx1 + one;
     let dy2 = dy1 - one;
     value = value + gradient(seed, xs_floor, ys_floor + one, dx2, dy2);
@@ -95,7 +95,7 @@ pub fn open_simplex2<T: Float>(seed: &Seed, point: &::Point2<T>) -> T {
     // See the graph for an intuitive explanation; the sum of `x` and `y` is
     // only greater than `1` if we're on Region B.
     if frac_sum > one {
-        // Point (1, 1)
+        // Contribution (1, 1)
         xs_floor = xs_floor + one;
         ys_floor = ys_floor + one;
         // We are moving across the diagonal `/`, so we'll need to add by the
@@ -132,32 +132,34 @@ pub fn open_simplex3<T: Float>(seed: &Seed, point: &::Point3<T>) -> T {
     let two: T = math::cast(2);
     let squish_constant: T = math::cast(SQUISH_CONSTANT_3D);
 
-    //Place input coordinates on simplectic honeycomb.
+    // Place input coordinates on simplectic honeycomb.
     let stretch_offset = (point[0] + point[1] + point[2]) * math::cast(STRETCH_CONSTANT_3D);
     let xs = point[0] + stretch_offset;
     let ys = point[1] + stretch_offset;
     let zs = point[2] + stretch_offset;
 
-    //Floor to get simplectic honeycomb coordinates of rhombohedron (stretched cube) super-cell origin.
+    // Floor to get simplectic honeycomb coordinates of rhombohedron
+    // (stretched cube) super-cell origin.
     let xsb = xs.floor();
     let ysb = ys.floor();
     let zsb = zs.floor();
 
-    //Skew out to get actual coordinates of rhombohedron origin. We'll need these later.
+    // Skew out to get actual coordinates of rhombohedron origin. We'll need
+    // these later.
     let squish_offset = (xsb + ysb + zsb) * squish_constant;
     let xb = xsb + squish_offset;
     let yb = ysb + squish_offset;
     let zb = zsb + squish_offset;
 
-    //Compute simplectic honeycomb coordinates relative to rhombohedral origin.
-    let xins = xs - xsb;
-    let yins = ys - ysb;
-    let zins = zs - zsb;
+    // Compute simplectic honeycomb coordinates relative to rhombohedral origin.
+    let xs_frac = xs - xsb;
+    let ys_frac = ys - ysb;
+    let zs_frac = zs - zsb;
 
-    //Sum those together to get a value that determines which region we're in.
-    let in_sum = xins + yins + zins;
+    // Sum those together to get a value that determines which region we're in.
+    let frac_sum = xs_frac + ys_frac + zs_frac;
 
-    //Positions relative to origin point.
+    // Positions relative to origin point.
     let mut dx0 = point[0] - xb;
     let mut dy0 = point[1] - yb;
     let mut dz0 = point[2] - zb;
@@ -165,83 +167,89 @@ pub fn open_simplex3<T: Float>(seed: &Seed, point: &::Point3<T>) -> T {
     let mut value = zero;
     let c0 = one + two * squish_constant;
 
-    if in_sum <= one { //We're inside the tetrahedron (3-Simplex) at (0,0,0)
-        //Contribution (0,0,0)
+    if frac_sum <= one {
+        // We're inside the tetrahedron (3-Simplex) at (0, 0, 0)
+
+        // Contribution at (0, 0, 0)
         value = value + gradient(seed, xsb, ysb, zsb, dx0, dy0, dz0);
 
-        //Contribution (1,0,0)
+        // Contribution at (1, 0, 0)
         let dx1 = dx0 - one - squish_constant;
         let dy1 = dy0 - squish_constant;
         let dz1 = dz0 - squish_constant;
         value = value + gradient(seed, xsb + one, ysb, zsb, dx1, dy1, dz1);
 
-        //Contribution (0,1,0)
+        // Contribution at (0, 1, 0)
         let dx2 = dx0 - squish_constant;
         let dy2 = dy1 - one;
         let dz2 = dz1;
         value = value + gradient(seed, xsb, ysb + one, zsb, dx2, dy2, dz2);
 
-        //Contribution (0,0,1)
+        // Contribution at (0, 0, 1)
         let dx3 = dx2;
         let dy3 = dy1;
         let dz3 = dz1 - one;
         value = value + gradient(seed, xsb, ysb, zsb + one, dx3, dy3, dz3);
-    } else if in_sum >= two { //We're inside the tetrahedron (3-Simplex) at (1,11)
-        //Contribution (1,1,0)
+    } else if frac_sum >= two {
+        // We're inside the tetrahedron (3-Simplex) at (1, 1, 1)
+
+        // Contribution at (1, 1, 0)
         let dx3 = dx0 - c0;
         let dy3 = dy0 - c0;
         let dz3 = dz0 - c0 + one;
         value = value + gradient(seed, xsb + one, ysb + one, zsb, dx3, dy3, dz3);
 
-        //Contribution (1,0,1)
+        // Contribution at (1, 0, 1)
         let dx2 = dx3;
         let dy2 = dy3 + one;
         let dz2 = dz3 - one;
         value = value + gradient(seed, xsb + one, ysb, zsb + one, dx2, dy2, dz2);
 
-        //Contribution (0,1,1)
+        // Contribution at (0, 1, 1)
         let dx1 = dx3 + one;
         let dy1 = dy3;
         let dz1 = dz2;
         value = value + gradient(seed, xsb, ysb + one, zsb + one, dx1, dy1, dz1);
 
-        //Contribution (1,1,1)
+        // Contribution at (1, 1, 1)
         dx0 = dx3 - squish_constant;
         dy0 = dy3 - squish_constant;
         dz0 = dz2 - squish_constant;
         value = value + gradient(seed, xsb + one, ysb + one, zsb + one, dx0, dy0, dz0);
-    } else { //We're inside the octahedron (Rectified 3-Simplex) in between.
-        //Contribution (1,0,0)
+    } else {
+        // We're inside the octahedron (Rectified 3-Simplex) inbetween.
+
+        // Contribution at (1, 0, 0)
         let dx1 = dx0 - one - squish_constant;
         let dy1 = dy0 - squish_constant;
         let dz1 = dz0 - squish_constant;
         value = value + gradient(seed, xsb + one, ysb, zsb, dx1, dy1, dz1);
 
-        //Contribution (0,1,0)
+        // Contribution at (0, 1, 0)
         let dx2 = dx1 + one;
         let dy2 = dy1 - one;
         let dz2 = dz1;
         value = value + gradient(seed, xsb, ysb + one, zsb, dx2, dy2, dz2);
 
-        //Contribution (0,0,1)
+        // Contribution at (0, 0, 1)
         let dx3 = dx2;
         let dy3 = dy1;
         let dz3 = dz1 - one;
         value = value + gradient(seed, xsb, ysb, zsb + one, dx3, dy3, dz3);
 
-        //Contribution (1,1,0)
+        // Contribution at (1, 1, 0)
         let dx4 = dx0 - c0;
         let dy4 = dy0 - c0;
         let dz4 = dz1 - squish_constant;
         value = value + gradient(seed, xsb + one, ysb + one, zsb, dx4, dy4, dz4);
 
-        //Contribution (1,0,1)
+        // Contribution at (1, 0, 1)
         let dx5 = dx4;
         let dy5 = dy4 + one;
         let dz5 = dz4 - one;
         value = value + gradient(seed, xsb + one, ysb, zsb + one, dx5, dy5, dz5);
 
-        //Contribution (0,1,1)
+        // Contribution at (0, 1, 1)
         let dx6 = dx4 + one;
         let dy6 = dy4;
         let dz6 = dz5;

--- a/src/open_simplex.rs
+++ b/src/open_simplex.rs
@@ -121,7 +121,6 @@ pub fn open_simplex3<T: Float>(seed: &Seed, point: &::Point3<T>) -> T {
     let zero: T = math::cast(0);
     let one: T = math::cast(1);
     let two: T = math::cast(2);
-    let three: T = math::cast(3);
     let squish_constant: T = math::cast(SQUISH_CONSTANT_3D);
 
     //Place input coordinates on simplectic honeycomb.
@@ -156,7 +155,6 @@ pub fn open_simplex3<T: Float>(seed: &Seed, point: &::Point3<T>) -> T {
 
     let mut value = zero;
     let c0 = one + two * squish_constant;
-    // let c1 = one - squish_constant;
 
     if in_sum <= one { //We're inside the tetrahedron (3-Simplex) at (0,0,0)
         //Contribution (0,0,0)
@@ -199,15 +197,16 @@ pub fn open_simplex3<T: Float>(seed: &Seed, point: &::Point3<T>) -> T {
         value = value + gradient(seed, xsb, ysb + one, zsb + one, dx1, dy1, dz1);
 
         //Contribution (1,1,1)
-        dx0 = dx0 - one - three * squish_constant;
-        dy0 = dy0 - one - three * squish_constant;
-        dz0 = dz0 - one - three * squish_constant;
+        let c1 = c0 + squish_constant;
+        dx0 = dx0 - c1;
+        dy0 = dy0 - c1;
+        dz0 = dz0 - c1;
         value = value + gradient(seed, xsb + one, ysb + one, zsb + one, dx0, dy0, dz0);
     } else { //We're inside the octahedron (Rectified 3-Simplex) in between.
         //Contribution (1,0,0)
         let dx1 = dx0 - one - squish_constant;
-        let dy1 = dy0 - zero - squish_constant;
-        let dz1 = dz0 - zero - squish_constant;
+        let dy1 = dy0 - squish_constant;
+        let dz1 = dz0 - squish_constant;
         value = value + gradient(seed, xsb + one, ysb, zsb, dx1, dy1, dz1);
 
         //Contribution (0,1,0)
@@ -219,7 +218,7 @@ pub fn open_simplex3<T: Float>(seed: &Seed, point: &::Point3<T>) -> T {
         //Contribution (0,0,1)
         let dx3 = dx2;
         let dy3 = dy1;
-        let dz3 = dz0 - one - squish_constant;
+        let dz3 = dz1 - one;
         value = value + gradient(seed, xsb, ysb, zsb + one, dx3, dy3, dz3);
 
         //Contribution (1,1,0)

--- a/src/open_simplex.rs
+++ b/src/open_simplex.rs
@@ -49,51 +49,62 @@ pub fn open_simplex2<T: Float>(seed: &Seed, point: &::Point2<T>) -> T {
     let one: T = math::cast(1);
     let squish_constant: T = math::cast(SQUISH_CONSTANT_2D);
 
-    //Place input coordinates onto grid.
+    // Place input coordinates onto grid.
     let stretch_offset = (point[0] + point[1]) * math::cast(STRETCH_CONSTANT_2D);
     let xs = point[0] + stretch_offset;
     let ys = point[1] + stretch_offset;
 
-    //Floor to get grid coordinates of rhombus (stretched square) super-cell origin.
+    // Floor to get grid coordinates of rhombus (stretched square) cell origin.
     let mut xs_floor = xs.floor();
     let mut ys_floor = ys.floor();
 
-    //Skew out to get actual coordinates of rhombus origin. We'll need these later.
+    // Skew out to get actual coordinates of rhombus origin. We'll need these later.
     let squish_offset = (xs_floor + ys_floor) * squish_constant;
     let x_floor = xs_floor + squish_offset;
     let y_floor = ys_floor + squish_offset;
 
-    //Compute grid coordinates relative to rhombus origin.
+    // Compute grid coordinates relative to rhombus origin.
     let xs_frac = xs - xs_floor;
     let ys_frac = ys - ys_floor;
 
-    //Sum those together to get a value that determines which region we're in.
+    // Sum those together to get a value that determines which region we're in.
     let frac_sum = xs_frac + ys_frac;
 
-    //Positions relative to origin point.
+    // Positions relative to origin point.
     let mut dx0 = point[0] - x_floor;
     let mut dy0 = point[1] - y_floor;
 
     let mut value: T = zero;
 
-    //Contribution (1,0)
+    // (0, 0) --- (1, 0)
+    // |   A     /     |
+    // |       /       |
+    // |     /     B   |
+    // (0, 1) --- (1, 1)
+
+    // Point (1, 0)
     let dx1 = dx0 - one - squish_constant;
     let dy1 = dy0 - squish_constant;
     value = value + gradient(seed, xs_floor + one, ys_floor, dx1, dy1);
 
-    //Contribution (0,1)
-    let dx2 = dx0 - squish_constant;
+    // Point (0, 1)
+    let dx2 = dx1 + one;
     let dy2 = dy1 - one;
     value = value + gradient(seed, xs_floor, ys_floor + one, dx2, dy2);
 
+    // See the graph for an intuitive explanation; the sum of `x` and `y` is
+    // only greater than `1` if we're on Region B.
     if frac_sum > one {
+        // Point (1, 1)
         xs_floor = xs_floor + one;
         ys_floor = ys_floor + one;
+        // We are moving across the diagonal `/`, so we'll need to add by the
+        // squish constant
         dx0 = dx1 - squish_constant;
         dy0 = dy2 - squish_constant;
     }
 
-    //Contribution (0,0) or (1,1)
+    // Point (0, 0) or (1, 1)
     value = value + gradient(seed, xs_floor, ys_floor, dx0, dy0);
 
     value * math::cast(NORM_CONSTANT_2D)

--- a/src/open_simplex.rs
+++ b/src/open_simplex.rs
@@ -83,15 +83,16 @@ pub fn open_simplex2<T: Float>(seed: &Seed, point: &::Point2<T>) -> T {
     value = value + gradient(seed, xs_floor + one, ys_floor + zero, dx1, dy1);
 
     //Contribution (0,1)
-    let dx2 = dx0 - zero - squish_constant;
-    let dy2 = dy0 - one - squish_constant;
+    let dx2 = dx1 + one;
+    let dy2 = dy1 - one;
     value = value + gradient(seed, xs_floor + zero, ys_floor + one, dx2, dy2);
 
     if frac_sum > one {
         xs_floor = xs_floor + one;
         ys_floor = ys_floor + one;
-        dx0 = dx0 - one - two * squish_constant;
-        dy0 = dy0 - one - two * squish_constant;
+        let t = one + two * squish_constant;
+        dx0 = dx0 - t;
+        dy0 = dy0 - t;
     }
 
     //Contribution (0,0) or (1,1)

--- a/src/open_simplex.rs
+++ b/src/open_simplex.rs
@@ -70,7 +70,7 @@ pub fn open_simplex2<T: Float>(seed: &Seed, point: &::Point2<T>) -> T {
     // Sum those together to get a value that determines which region we're in.
     let frac_sum = xs_frac + ys_frac;
 
-    // Positions relative to origin point.
+    // Positions relative to origin point (0, 0).
     let mut dx0 = point[0] - x_floor;
     let mut dy0 = point[1] - y_floor;
 


### PR DESCRIPTION
Removes most of the duplicate calculations and tries to use previously-computed values as much as possible.

### Benchmarks

**Before**

```
test bench_open_simplex2               ... bench:          26 ns/iter (+/- 1)
test bench_open_simplex2_64x64         ... bench:     104,816 ns/iter (+/- 1,131)
test bench_open_simplex3               ... bench:          52 ns/iter (+/- 3)
test bench_open_simplex3_64x64         ... bench:     169,494 ns/iter (+/- 794)
```

**After**

```
test bench_open_simplex2               ... bench:          25 ns/iter (+/- 1)
test bench_open_simplex2_64x64         ... bench:      99,244 ns/iter (+/- 1,410)
test bench_open_simplex3               ... bench:          50 ns/iter (+/- 2)
test bench_open_simplex3_64x64         ... bench:     163,044 ns/iter (+/- 1,071)
```

Running on Ubuntu 14.04 x64 in VirtualBox.

Rust toolchain:

```
nightly-x86_64-unknown-linux-gnu (default)
rustc 1.11.0-nightly (ad7fe6521 2016-06-23)
```