### PR TITLE
OpenSimplex 4D

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ A slower but higher quality form of gradient noise:
 
 - `open_simplex2`
 - `open_simplex3`
+- `open_simplex4`
 
 ### Value Noise
 
@@ -164,9 +165,3 @@ These functions, when given a point, will return the cell of the nearest seed po
 - `cell2_seed_cell`
 - `cell3_seed_cell`
 - `cell4_seed_cell`
-
-### Coming soon
-
-Everything below this line is planned, but not yet implemented:
-
-- `open_simplex4`

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -21,7 +21,7 @@ extern crate test;
 
 use noise::Seed;
 use noise::{perlin2, perlin3, perlin4};
-use noise::{open_simplex2, open_simplex3};
+use noise::{open_simplex2, open_simplex3, open_simplex4};
 use noise::{value2, value3, value4};
 use noise::{cell2_range, cell3_range, cell4_range};
 use noise::{cell2_range_inv, cell3_range_inv, cell4_range_inv};
@@ -59,6 +59,12 @@ fn bench_open_simplex2(bencher: &mut Bencher) {
 fn bench_open_simplex3(bencher: &mut Bencher) {
     let seed = Seed::new(0);
     bencher.iter(|| open_simplex3(black_box(&seed), black_box(&[42.0f64, 37.0, 26.0])));
+}
+
+#[bench]
+fn bench_open_simplex4(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| open_simplex4(black_box(&seed), black_box(&[42.0f64, 37.0, 26.0, 128.0])));
 }
 
 #[bench]
@@ -242,6 +248,18 @@ fn bench_open_simplex3_64x64(bencher: &mut Bencher) {
         for y in 0..64 {
             for x in 0..64 {
                 black_box(open_simplex3(black_box(&seed), &[x as f64, y as f64, x as f64]));
+            }
+        }
+    });
+}
+
+#[bench]
+fn bench_open_simplex4_64x64(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| {
+        for y in 0..64 {
+            for x in 0..64 {
+                black_box(open_simplex4(black_box(&seed), &[x as f64, y as f64, x as f64, y as f64]));
             }
         }
     });

--- a/examples/open_simplex.rs
+++ b/examples/open_simplex.rs
@@ -16,14 +16,15 @@
 
 extern crate noise;
 
-use noise::{open_simplex2, open_simplex3, Seed, Point2};
+use noise::{open_simplex2, open_simplex3, open_simplex4, Seed, Point2};
 
 mod debug;
 
 fn main() {
     debug::render_png("open_simplex2.png", &Seed::new(0), 1024, 1024, scaled_open_simplex2);
     debug::render_png("open_simplex3.png", &Seed::new(0), 1024, 1024, scaled_open_simplex3);
-    println!("\nGenerated open_simplex2.png and open_simplex3.png");
+    debug::render_png("open_simplex4.png", &Seed::new(0), 1024, 1024, scaled_open_simplex4);
+    println!("\nGenerated open_simplex2.png, open_simplex3.png and open_simplex4.png");
 }
 
 fn scaled_open_simplex2(seed: &Seed, point: &Point2<f64>) -> f64 {
@@ -32,4 +33,8 @@ fn scaled_open_simplex2(seed: &Seed, point: &Point2<f64>) -> f64 {
 
 fn scaled_open_simplex3(seed: &Seed, point: &Point2<f64>) -> f64 {
     open_simplex3(seed, &[point[0] / 16.0, point[1] / 16.0, point[0] / 32.0])
+}
+
+fn scaled_open_simplex4(seed: &Seed, point: &Point2<f64>) -> f64 {
+    open_simplex4(seed, &[point[0] / 16.0, point[1] / 16.0, point[0] / 32.0, point[1] / 32.0])
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ pub use seed::Seed;
 pub use math::{Point2, Point3, Point4};
 pub use perlin::{perlin2, perlin3, perlin4};
 pub use value::{value2, value3, value4};
-pub use open_simplex::{open_simplex2, open_simplex3};
+pub use open_simplex::{open_simplex2, open_simplex3, open_simplex4};
 pub use brownian::{Brownian2, Brownian3, Brownian4};
 
 pub use cell::{range_sqr_euclidian2, range_sqr_euclidian3, range_sqr_euclidian4};

--- a/src/open_simplex.rs
+++ b/src/open_simplex.rs
@@ -337,8 +337,8 @@ pub fn open_simplex4<T: Float>(seed: &Seed, point: &math::Point4<T>) -> T {
         {
             let vertex = math::add4(stretched_floor, [zero, one, zero, zero]);
             pos2 = [
-                pos1[0] - one,
-                pos1[1] + one,
+                pos1[0] + one,
+                pos1[1] - one,
                 pos1[2],
                 pos1[3]
             ];
@@ -361,7 +361,7 @@ pub fn open_simplex4<T: Float>(seed: &Seed, point: &math::Point4<T>) -> T {
         // Contribution at (0, 0, 0, 1)
         let pos4;
         {
-            let vertex = math::add4(stretched_floor, [zero, zero, one, zero]);
+            let vertex = math::add4(stretched_floor, [zero, zero, zero, one]);
             pos4 = [
                 pos2[0],
                 pos1[1],
@@ -418,7 +418,7 @@ pub fn open_simplex4<T: Float>(seed: &Seed, point: &math::Point4<T>) -> T {
         {
             let vertex = math::add4(stretched_floor, [zero, one, one, one]);
             pos1 = [
-                pos4[0] + one,
+                pos0[0] - squish_constant_3,
                 pos4[1],
                 pos4[2],
                 pos3[3]
@@ -587,7 +587,7 @@ pub fn open_simplex4<T: Float>(seed: &Seed, point: &math::Point4<T>) -> T {
         // Contribution at (1, 1, 0, 1)
         let pos3;
         {
-            let vertex = math::add4(stretched_floor, [zero, one, zero, zero]);
+            let vertex = math::add4(stretched_floor, [one, one, zero, one]);
             pos3 = [
                 pos4[0],
                 pos4[1],
@@ -596,8 +596,6 @@ pub fn open_simplex4<T: Float>(seed: &Seed, point: &math::Point4<T>) -> T {
             ];
             value = value + gradient(seed, &vertex, &pos3);
         }
-
-        // oh my god this is tiring.
 
         // Contribution at (1, 0, 1, 1)
         let pos2;

--- a/src/open_simplex.rs
+++ b/src/open_simplex.rs
@@ -309,7 +309,7 @@ pub fn open_simplex4<T: Float>(seed: &Seed, point: &math::Point4<T>) -> T {
     let region_sum = math::fold4(rel_coords, Add::add);
 
     // Position relative to origin point.
-    let pos0 = math::sub4(*point, skewed_floor);
+    let mut pos0 = math::sub4(*point, skewed_floor);
 
     let mut value = zero;
     if region_sum <= one {
@@ -344,9 +344,31 @@ pub fn open_simplex4<T: Float>(seed: &Seed, point: &math::Point4<T>) -> T {
             value = value + gradient(seed, &vertex, &pos2);
         }
 
-        // TODO
-		// Contribution at (0, 0, 1, 0)
-		// Contribution at (0, 0, 0, 1)
+        // Contribution at (0, 0, 1, 0)
+        let pos3;
+        {
+            let vertex = math::add4(stretched_floor, [zero, zero, one, zero]);
+            pos3 = [
+                pos2[0],
+                pos1[1],
+                pos1[2] - one,
+                pos1[3]
+            ];
+            value = value + gradient(seed, &vertex, &pos3);
+        }
+
+        // Contribution at (0, 0, 0, 1)
+        let pos4;
+        {
+            let vertex = math::add4(stretched_floor, [zero, zero, one, zero]);
+            pos4 = [
+                pos2[0],
+                pos1[1],
+                pos1[2],
+                pos1[3] - one
+            ];
+            value = value + gradient(seed, &vertex, &pos4);
+        }
     } else if region_sum >= three {
         // We're inside the pentachoron (4-Simplex) at (1, 1, 1, 1)
         let squish_constant_3 = three * squish_constant;
@@ -377,9 +399,41 @@ pub fn open_simplex4<T: Float>(seed: &Seed, point: &math::Point4<T>) -> T {
             value = value + gradient(seed, &vertex, &pos3);
         }
 
-        // TODO
-		// Contribution at (1, 0, 1, 1)
-		// Contribution at (0, 1, 1, 1)
+        // Contribution at (1, 0, 1, 1)
+        let pos2;
+        {
+            let vertex = math::add4(stretched_floor, [one, zero, one, one]);
+            pos2 = [
+                pos4[0],
+                pos4[1] + one,
+                pos4[2],
+                pos3[3]
+            ];
+            value = value + gradient(seed, &vertex, &pos2);
+        }
+
+        // Contribution at (0, 1, 1, 1)
+        let pos1;
+        {
+            let vertex = math::add4(stretched_floor, [zero, one, one, one]);
+            pos1 = [
+                pos4[0] + one,
+                pos4[1],
+                pos4[2],
+                pos3[3]
+            ];
+            value = value + gradient(seed, &vertex, &pos1);
+        }
+
+        // Contribution at (1, 1, 1, 1)
+        {
+            let vertex = math::add4(stretched_floor, [one, one, one, one]);
+            pos0[0] = pos4[0] - squish_constant;
+            pos0[1] = pos4[1] - squish_constant;
+            pos0[2] = pos4[2] - squish_constant;
+            pos0[3] = pos3[3] - squish_constant;
+            value = value + gradient(seed, &vertex, &pos0);
+        }
     } else if region_sum <= two {
         // We're inside the first dispentachoron (Rectified 4-Simplex)
 
@@ -409,15 +463,109 @@ pub fn open_simplex4<T: Float>(seed: &Seed, point: &math::Point4<T>) -> T {
             value = value + gradient(seed, &vertex, &pos2);
         }
 
-        // TODO
         // Contribution at (0, 0, 1, 0)
+        let pos3;
+        {
+            let vertex = math::add4(stretched_floor, [zero, zero, one, zero]);
+            pos3 = [
+                pos2[0],
+                pos1[1],
+                pos1[2] - one,
+                pos1[3]
+            ];
+            value = value + gradient(seed, &vertex, &pos3);
+        }
+
         // Contribution at (0, 0, 0, 1)
+        let pos4;
+        {
+            let vertex = math::add4(stretched_floor, [zero, zero, zero, one]);
+            pos4 = [
+                pos2[0],
+                pos1[1],
+                pos1[2],
+                pos1[3] - one
+            ];
+            value = value + gradient(seed, &vertex, &pos4);
+        }
+
         // Contribution at (1, 1, 0, 0)
+        let pos5;
+        {
+            let vertex = math::add4(stretched_floor, [one, one, zero, zero]);
+            pos5 = [
+                pos1[0] - squish_constant,
+                pos2[1] - squish_constant,
+                pos1[2] - squish_constant,
+                pos1[3] - squish_constant
+            ];
+            value = value + gradient(seed, &vertex, &pos5);
+        }
+
         // Contribution at (1, 0, 1, 0)
+        let pos6;
+        {
+            let vertex = math::add4(stretched_floor, [one, zero, one, zero]);
+            pos6 = [
+                pos5[0],
+                pos5[1] + one,
+                pos5[2] - one,
+                pos5[3]
+            ];
+            value = value + gradient(seed, &vertex, &pos6);
+        }
+
         // Contribution at (1, 0, 0, 1)
+        let pos7;
+        {
+            let vertex = math::add4(stretched_floor, [one, zero, zero, one]);
+            pos7 = [
+                pos5[0],
+                pos6[1],
+                pos5[2],
+                pos5[3] - one
+            ];
+            value = value + gradient(seed, &vertex, &pos7);
+        }
+
         // Contribution at (0, 1, 1, 0)
+        let pos8;
+        {
+            let vertex = math::add4(stretched_floor, [zero, one, one, zero]);
+            pos8 = [
+                pos5[0] + one,
+                pos5[1],
+                pos6[2],
+                pos5[3]
+            ];
+            value = value + gradient(seed, &vertex, &pos8);
+        }
+
         // Contribution at (0, 1, 0, 1)
+        let pos9;
+        {
+            let vertex = math::add4(stretched_floor, [zero, one, zero, one]);
+            pos9 = [
+                pos8[0],
+                pos5[1],
+                pos5[2],
+                pos7[3]
+            ];
+            value = value + gradient(seed, &vertex, &pos9);
+        }
+
         // Contribution at (0, 0, 1, 1)
+        let pos10;
+        {
+            let vertex = math::add4(stretched_floor, [zero, zero, one, one]);
+            pos10 = [
+                pos8[0],
+                pos6[1],
+                pos6[2],
+                pos7[3]
+            ];
+            value = value + gradient(seed, &vertex, &pos10);
+        }
     } else {
         // We're inside the second dispentachoron (Rectified 4-Simplex)
         let squish_constant_3 = three * squish_constant;
@@ -475,7 +623,88 @@ pub fn open_simplex4<T: Float>(seed: &Seed, point: &math::Point4<T>) -> T {
             ];
             value = value + gradient(seed, &vertex, &pos1);
         }
+
+        // Contribution at (1, 1, 0, 0)
+        let pos5;
+        {
+            let vertex = math::add4(stretched_floor, [one, one, zero, zero]);
+            pos5 = [
+                pos4[0] + squish_constant,
+                pos4[1] + squish_constant,
+                pos3[2] + squish_constant,
+                pos4[3] + squish_constant
+            ];
+            value = value + gradient(seed, &vertex, &pos5);
+        }
+
+        // Contribution at (1, 0, 1, 0)
+        let pos6;
+        {
+            let vertex = math::add4(stretched_floor, [one, zero, one, zero]);
+            pos6 = [
+                pos5[0],
+                pos5[1] + one,
+                pos5[2] - one,
+                pos5[3]
+            ];
+            value = value + gradient(seed, &vertex, &pos6);
+        }
+
+        // Contribution at (1, 0, 0, 1)
+        let pos7;
+        {
+            let vertex = math::add4(stretched_floor, [one, zero, zero, one]);
+            pos7 = [
+                pos5[0],
+                pos6[1],
+                pos5[2],
+                pos5[3] - one
+            ];
+            value = value + gradient(seed, &vertex, &pos7);
+        }
+
+        // Contribution at (0, 1, 1, 0)
+        let pos8;
+        {
+            let vertex = math::add4(stretched_floor, [zero, one, one, zero]);
+            pos8 = [
+                pos5[0] + one,
+                pos5[1],
+                pos6[2],
+                pos5[3]
+            ];
+            value = value + gradient(seed, &vertex, &pos8);
+        }
+
+        // Contribution at (0, 1, 0, 1)
+        let pos9;
+        {
+            let vertex = math::add4(stretched_floor, [zero, one, zero, one]);
+            pos9 = [
+                pos8[0],
+                pos5[1],
+                pos5[2],
+                pos7[3]
+            ];
+            value = value + gradient(seed, &vertex, &pos9);
+        }
+
+        // Contribution at (0, 0, 1, 1)
+        let pos10;
+        {
+            let vertex = math::add4(stretched_floor, [zero, zero, one, one]);
+            pos10 = [
+                pos8[0],
+                pos6[1],
+                pos6[2],
+                pos7[3]
+            ];
+            value = value + gradient(seed, &vertex, &pos10);
+        }
     }
+
+    // Please tell me you did not just read the whole thing thinking how to
+    // optimize it.
 
     value
 }

--- a/src/open_simplex.rs
+++ b/src/open_simplex.rs
@@ -30,7 +30,7 @@ const SQUISH_CONSTANT_4D: f64 = 0.309016994374947; //(Math.sqrt(4+1)-1)/4;
 
 const NORM_CONSTANT_2D: f32 = 1.0 / 14.0;
 const NORM_CONSTANT_3D: f32 = 1.0 / 14.0;
-const NORM_CONSTANT_4D: f32 = 1.0 / 15.0;
+const NORM_CONSTANT_4D: f32 = 1.0 / 6.8699090070956625;
 
 /// 2-dimensional [OpenSimplex Noise](http://uniblock.tumblr.com/post/97868843242/noise)
 ///

--- a/src/open_simplex.rs
+++ b/src/open_simplex.rs
@@ -268,11 +268,11 @@ pub fn open_simplex3<T: Float>(seed: &Seed, point: &::Point3<T>) -> T {
 /// This is a slower but higher quality form of gradient noise than
 /// `noise::perlin4`.
 pub fn open_simplex4<T: Float>(seed: &Seed, point: &math::Point4<T>) -> T {
-    fn gradient<T: Float>(seed: &Seed, stretched_floor: &math::Point4<T>, pos: &math::Point4<T>) -> T {
-        let zero: T = math::cast(0.0);
+    fn gradient<T: Float>(seed: &Seed, vertex: &math::Point4<T>, pos: &math::Point4<T>) -> T {
+        let zero = T::zero();
         let attn = math::cast::<_, T>(2.0_f64) - math::dot4(*pos, *pos);
         if attn > zero {
-            let index = seed.get4::<isize>(math::cast4::<_, isize>(*stretched_floor));
+            let index = seed.get4::<isize>(math::cast4::<_, isize>(*vertex));
             let vec = gradient::get4::<T>(index);
             math::pow4(attn) * math::dot4(*pos, vec)
         } else {
@@ -283,8 +283,8 @@ pub fn open_simplex4<T: Float>(seed: &Seed, point: &math::Point4<T>) -> T {
     // Constants.
     let stretch_constant: T = math::cast(STRETCH_CONSTANT_4D);
     let squish_constant: T = math::cast(SQUISH_CONSTANT_4D);
-    let zero: T = math::cast(0.0);
-    let one: T = math::cast(1.0);
+    let zero = T::zero();
+    let one = T::one();
     let two: T = math::cast(2.0);
     let three: T = math::cast(3.0);
 

--- a/src/open_simplex.rs
+++ b/src/open_simplex.rs
@@ -17,6 +17,7 @@
 //! http://uniblock.tumblr.com/post/97868843242/noise
 
 use num_traits::Float;
+use std::ops::{Add};
 
 use {gradient, math, Seed};
 
@@ -24,6 +25,8 @@ const STRETCH_CONSTANT_2D: f64 = -0.211324865405187; //(1/sqrt(2+1)-1)/2;
 const SQUISH_CONSTANT_2D: f64 = 0.366025403784439; //(sqrt(2+1)-1)/2;
 const STRETCH_CONSTANT_3D: f64 = -1.0 / 6.0; //(1/Math.sqrt(3+1)-1)/3;
 const SQUISH_CONSTANT_3D: f64 = 1.0 / 3.0; //(Math.sqrt(3+1)-1)/3;
+const STRETCH_CONSTANT_4D: f64 = -0.138196601125011; //(Math.sqrt(4+1)-1)/4;
+const SQUISH_CONSTANT_4D: f64 = 0.309016994374947; //(Math.sqrt(4+1)-1)/4;
 
 const NORM_CONSTANT_2D: f32 = 1.0 / 14.0;
 const NORM_CONSTANT_3D: f32 = 1.0 / 14.0;
@@ -257,4 +260,222 @@ pub fn open_simplex3<T: Float>(seed: &Seed, point: &::Point3<T>) -> T {
     }
 
     return value * math::cast(NORM_CONSTANT_3D);
+}
+
+/// 4-dimensional [OpenSimplex Noise](http://uniblock.tumblr.com/post/97868843242/noise)
+///
+/// This is a slower but higher quality form of gradient noise than
+/// `noise::perlin4`.
+pub fn open_simplex4<T: Float>(seed: &Seed, point: &math::Point4<T>) -> T {
+    fn gradient<T: Float>(seed: &Seed, stretched_floor: &math::Point4<T>, pos: &math::Point4<T>) -> T {
+        let zero: T = math::cast(0.0);
+        let attn = math::cast::<_, T>(2.0_f64) - math::dot4(*pos, *pos);
+        if attn > zero {
+            let index = seed.get4::<isize>(math::cast4::<_, isize>(*stretched_floor));
+            let vec = gradient::get4::<T>(index);
+            math::pow4(attn) * math::dot4(*pos, vec)
+        } else {
+            zero
+        }
+    }
+
+    // Constants.
+    let stretch_constant: T = math::cast(STRETCH_CONSTANT_4D);
+    let squish_constant: T = math::cast(SQUISH_CONSTANT_4D);
+    let zero: T = math::cast(0.0);
+    let one: T = math::cast(1.0);
+    let two: T = math::cast(2.0);
+    let three: T = math::cast(3.0);
+
+    // Place input coordinates on simplectic honeycomb.
+    let stretch_offset = math::fold4(*point, Add::add) * stretch_constant;
+    let stretched = math::map4(*point, |v| v + stretch_offset);
+
+    // Floor to get simplectic honeycomb coordinates of rhombo-hypercube
+    // super-cell origin.
+    let stretched_floor = math::map4(stretched, Float::floor);
+
+    // Skew out to get actual coordinates of stretched rhombo-hypercube origin.
+    // We'll need these later.
+    let squish_offset = math::fold4(stretched_floor, Add::add) * squish_constant;
+    let skewed_floor = math::map4(stretched_floor, |v| v + squish_offset);
+
+    // Compute simplectic honeycomb coordinates relative to rhombo-hypercube
+    // origin.
+    let rel_coords = math::sub4(stretched, stretched_floor);
+
+    // Sum those together to get a value that determines which region
+    // we're in.
+    let region_sum = math::fold4(rel_coords, Add::add);
+
+    // Position relative to origin point.
+    let pos0 = math::sub4(*point, skewed_floor);
+
+    let mut value = zero;
+    if region_sum <= one {
+        // We're inside the pentachoron (4-Simplex) at (0, 0, 0, 0)
+
+        // Contribution at (0, 0, 0, 0)
+        value = value + gradient(seed, &stretched_floor, &pos0);
+
+        // Contribution at (1, 0, 0, 0)
+        let pos1;
+        {
+            let vertex = math::add4(stretched_floor, [one, zero, zero, zero]);
+            pos1 = math::sub4(pos0, [
+                one + squish_constant,
+                squish_constant,
+                squish_constant,
+                squish_constant
+            ]);
+            value = value + gradient(seed, &vertex, &pos1);
+        }
+
+        // Contribution at (0, 1, 0, 0)
+        let pos2;
+        {
+            let vertex = math::add4(stretched_floor, [zero, one, zero, zero]);
+            pos2 = [
+                pos1[0] - one,
+                pos1[1] + one,
+                pos1[2],
+                pos1[3]
+            ];
+            value = value + gradient(seed, &vertex, &pos2);
+        }
+
+        // TODO
+		// Contribution at (0, 0, 1, 0)
+		// Contribution at (0, 0, 0, 1)
+    } else if region_sum >= three {
+        // We're inside the pentachoron (4-Simplex) at (1, 1, 1, 1)
+        let squish_constant_3 = three * squish_constant;
+
+        // Contribution at (1, 1, 1, 0)
+        let pos4;
+        {
+            let vertex = math::add4(stretched_floor, [one, one, one, zero]);
+            pos4 = math::sub4(pos0, [
+                one + squish_constant_3,
+                one + squish_constant_3,
+                one + squish_constant_3,
+                squish_constant_3
+            ]);
+            value = value + gradient(seed, &vertex, &pos4);
+        }
+
+        // Contribution at (1, 1, 0, 1)
+        let pos3;
+        {
+            let vertex = math::add4(stretched_floor, [one, one, zero, one]);
+            pos3 = [
+                pos4[0],
+                pos4[1],
+                pos4[2] + one,
+                pos4[3] - one
+            ];
+            value = value + gradient(seed, &vertex, &pos3);
+        }
+
+        // TODO
+		// Contribution at (1, 0, 1, 1)
+		// Contribution at (0, 1, 1, 1)
+    } else if region_sum <= two {
+        // We're inside the first dispentachoron (Rectified 4-Simplex)
+
+        // Contribution at (1, 0, 0, 0)
+        let pos1;
+        {
+            let vertex = math::add4(stretched_floor, [one, zero, zero, zero]);
+            pos1 = math::sub4(pos0, [
+                one + squish_constant,
+                squish_constant,
+                squish_constant,
+                squish_constant
+            ]);
+            value = value + gradient(seed, &vertex, &pos1);
+        }
+
+        // Contribution at (0, 1, 0, 0)
+        let pos2;
+        {
+            let vertex = math::add4(stretched_floor, [zero, one, zero, zero]);
+            pos2 = [
+                pos1[0] + one,
+                pos1[1] - one,
+                pos1[2],
+                pos1[3]
+            ];
+            value = value + gradient(seed, &vertex, &pos2);
+        }
+
+        // TODO
+        // Contribution at (0, 0, 1, 0)
+        // Contribution at (0, 0, 0, 1)
+        // Contribution at (1, 1, 0, 0)
+        // Contribution at (1, 0, 1, 0)
+        // Contribution at (1, 0, 0, 1)
+        // Contribution at (0, 1, 1, 0)
+        // Contribution at (0, 1, 0, 1)
+        // Contribution at (0, 0, 1, 1)
+    } else {
+        // We're inside the second dispentachoron (Rectified 4-Simplex)
+        let squish_constant_3 = three * squish_constant;
+
+        // Contribution at (1, 1, 1, 0)
+        let pos4;
+        {
+            let vertex = math::add4(stretched_floor, [one, one, one, zero]);
+            pos4 = math::sub4(pos0, [
+                one + squish_constant_3,
+                one + squish_constant_3,
+                one + squish_constant_3,
+                squish_constant_3
+            ]);
+            value = value + gradient(seed, &vertex, &pos4);
+        }
+
+        // Contribution at (1, 1, 0, 1)
+        let pos3;
+        {
+            let vertex = math::add4(stretched_floor, [zero, one, zero, zero]);
+            pos3 = [
+                pos4[0],
+                pos4[1],
+                pos4[2] + one,
+                pos4[3] - one
+            ];
+            value = value + gradient(seed, &vertex, &pos3);
+        }
+
+        // oh my god this is tiring.
+
+        // Contribution at (1, 0, 1, 1)
+        let pos2;
+        {
+            let vertex = math::add4(stretched_floor, [one, zero, one, one]);
+            pos2 = [
+                pos4[0],
+                pos4[1] + one,
+                pos4[2],
+                pos3[3]
+            ];
+            value = value + gradient(seed, &vertex, &pos2);
+        }
+
+        // Contribution at (0, 1, 1, 1)
+        let pos1;
+        {
+            let vertex = math::add4(stretched_floor, [zero, one, one, one]);
+            pos1 = [
+                pos4[0] + one,
+                pos4[1],
+                pos4[2],
+                pos3[3]
+            ];
+            value = value + gradient(seed, &vertex, &pos1);
+        }
+    }
+
+    value
 }

--- a/src/open_simplex.rs
+++ b/src/open_simplex.rs
@@ -30,6 +30,7 @@ const SQUISH_CONSTANT_4D: f64 = 0.309016994374947; //(Math.sqrt(4+1)-1)/4;
 
 const NORM_CONSTANT_2D: f32 = 1.0 / 14.0;
 const NORM_CONSTANT_3D: f32 = 1.0 / 14.0;
+const NORM_CONSTANT_4D: f32 = 1.0 / 15.0;
 
 /// 2-dimensional [OpenSimplex Noise](http://uniblock.tumblr.com/post/97868843242/noise)
 ///
@@ -703,8 +704,5 @@ pub fn open_simplex4<T: Float>(seed: &Seed, point: &math::Point4<T>) -> T {
         }
     }
 
-    // Please tell me you did not just read the whole thing thinking how to
-    // optimize it.
-
-    value
+    value * math::cast(NORM_CONSTANT_4D)
 }


### PR DESCRIPTION
Whooo I'm done.

Currently not optimized very well. Follows the Java source semi-closely. I also chose a "correct" normalizing constant through trial-and-error.

Resolves #114.

![open_simplex4](https://cloud.githubusercontent.com/assets/9031092/16411832/ac39e090-3d5b-11e6-87a3-7b7c13dc83cf.png)

### Benchmark

![ss 2016-06-28 at 06 12 30](https://cloud.githubusercontent.com/assets/9031092/16411875/e5a51322-3d5b-11e6-95ad-841ea34ab374.png)

I think this is as fast as it can be right now. It's pretty unfair to compare it to Perlin noise considering that OpenSimplex has more cases and is focused on quality — the current Perlin noise implementation has pretty obvious grid-aligned artifacts for example.

### Optimizations

Not really optimized at the moment. A lot of duplicate code can be removed. See [C# port of OpenSimplex](https://gist.github.com/digitalshadow/134a3a02b67cecd72181).
