### PR TITLE
Move "Generated ..." messages out of the examples

### DIFF
--- a/examples/brownian.rs
+++ b/examples/brownian.rs
@@ -24,7 +24,6 @@ fn main() {
     debug::render_png("brownian2.png", &PermutationTable::new(0), 1024, 1024, brownian2_for_image);
     debug::render_png("brownian3.png", &PermutationTable::new(0), 1024, 1024, brownian3_for_image);
     debug::render_png("brownian4.png", &PermutationTable::new(0), 1024, 1024, brownian4_for_image);
-    println!("\nGenerated brownian2.png, brownian3.png and brownian4.png");
 }
 
 fn brownian2_for_image(perm_table: &PermutationTable, point: &Point2<f64>) -> f64 {

--- a/examples/cell_manhattan.rs
+++ b/examples/cell_manhattan.rs
@@ -24,7 +24,6 @@ fn main() {
     debug::render_png("cell2_manhattan.png", &PermutationTable::new(0), 1024, 1024, scaled_cell2_manhattan);
     debug::render_png("cell3_manhattan.png", &PermutationTable::new(0), 1024, 1024, scaled_cell3_manhattan);
     debug::render_png("cell4_manhattan.png", &PermutationTable::new(0), 1024, 1024, scaled_cell4_manhattan);
-    println!("\nGenerated cell2_manhattan.png, cell3_manhattan.png and cell4_manhattan.png");
 }
 
 fn scaled_cell2_manhattan(perm_table: &PermutationTable, point: &Point2<f64>) -> f64 {

--- a/examples/cell_manhattan_inv.rs
+++ b/examples/cell_manhattan_inv.rs
@@ -24,7 +24,6 @@ fn main() {
     debug::render_png("cell2_manhattan_inv.png", &PermutationTable::new(0), 1024, 1024, scaled_cell2_manhattan_inv);
     debug::render_png("cell3_manhattan_inv.png", &PermutationTable::new(0), 1024, 1024, scaled_cell3_manhattan_inv);
     debug::render_png("cell4_manhattan_inv.png", &PermutationTable::new(0), 1024, 1024, scaled_cell4_manhattan_inv);
-    println!("\nGenerated cell2_manhattan_inv.png, cell3_manhattan_inv.png and cell4_manhattan_inv.png");
 }
 
 fn scaled_cell2_manhattan_inv(perm_table: &PermutationTable, point: &Point2<f64>) -> f64 {

--- a/examples/cell_manhattan_value.rs
+++ b/examples/cell_manhattan_value.rs
@@ -24,7 +24,6 @@ fn main() {
     debug::render_png("cell2_manhattan_value.png", &PermutationTable::new(0), 1024, 1024, scaled_cell2_manhattan_value);
     debug::render_png("cell3_manhattan_value.png", &PermutationTable::new(0), 1024, 1024, scaled_cell3_manhattan_value);
     debug::render_png("cell4_manhattan_value.png", &PermutationTable::new(0), 1024, 1024, scaled_cell4_manhattan_value);
-    println!("\nGenerated cell2_manhattan_value.png, cell3_manhattan_value.png and cell4_manhattan_value.png");
 }
 
 fn scaled_cell2_manhattan_value(perm_table: &PermutationTable, point: &Point2<f64>) -> f64 {

--- a/examples/cell_range.rs
+++ b/examples/cell_range.rs
@@ -24,7 +24,6 @@ fn main() {
     debug::render_png("cell2_range.png", &PermutationTable::new(0), 1024, 1024, scaled_cell2_range);
     debug::render_png("cell3_range.png", &PermutationTable::new(0), 1024, 1024, scaled_cell3_range);
     debug::render_png("cell4_range.png", &PermutationTable::new(0), 1024, 1024, scaled_cell4_range);
-    println!("\nGenerated cell2_range.png, cell3_range.png and cell4_range.png");
 }
 
 fn scaled_cell2_range(perm_table: &PermutationTable, point: &Point2<f64>) -> f64 {

--- a/examples/cell_range_inv.rs
+++ b/examples/cell_range_inv.rs
@@ -24,7 +24,6 @@ fn main() {
     debug::render_png("cell2_range_inv.png", &PermutationTable::new(0), 1024, 1024, scaled_cell2_range_inv);
     debug::render_png("cell3_range_inv.png", &PermutationTable::new(0), 1024, 1024, scaled_cell3_range_inv);
     debug::render_png("cell4_range_inv.png", &PermutationTable::new(0), 1024, 1024, scaled_cell4_range_inv);
-    println!("\nGenerated cell2_range_inv.png, cell3_range_inv.png and cell4_range_inv.png");
 }
 
 fn scaled_cell2_range_inv(perm_table: &PermutationTable, point: &Point2<f64>) -> f64 {

--- a/examples/cell_value.rs
+++ b/examples/cell_value.rs
@@ -24,7 +24,6 @@ fn main() {
     debug::render_png("cell2_value.png", &PermutationTable::new(0), 1024, 1024, scaled_cell2_value);
     debug::render_png("cell3_value.png", &PermutationTable::new(0), 1024, 1024, scaled_cell3_value);
     debug::render_png("cell4_value.png", &PermutationTable::new(0), 1024, 1024, scaled_cell4_value);
-    println!("\nGenerated cell2_value.png, cell3_value.png and cell4_value.png");
 }
 
 fn scaled_cell2_value(perm_table: &PermutationTable, point: &Point2<f64>) -> f64 {

--- a/examples/debug/mod.rs
+++ b/examples/debug/mod.rs
@@ -46,5 +46,11 @@ pub fn render_png<T, F>(filename: &str, perm_table: &noise::PermutationTable, wi
         }
     }
 
-    let _ = image::save_buffer(&Path::new(filename), &*pixels, width, height, image::Gray(8));
+    let _ = image::save_buffer(&Path::new(filename),
+                               &*pixels,
+                               width,
+                               height,
+                               image::Gray(8));
+
+    println!("\nGenerated {}", filename);
 }

--- a/examples/perlin.rs
+++ b/examples/perlin.rs
@@ -24,7 +24,6 @@ fn main() {
     debug::render_png("perlin2.png", &PermutationTable::new(0), 1024, 1024, scaled_perlin2);
     debug::render_png("perlin3.png", &PermutationTable::new(0), 1024, 1024, scaled_perlin3);
     debug::render_png("perlin4.png", &PermutationTable::new(0), 1024, 1024, scaled_perlin4);
-    println!("\nGenerated perlin2.png, perlin3.png and perlin4.png");
 }
 
 fn scaled_perlin2(perm_table: &PermutationTable, point: &Point2<f64>) -> f64 {

--- a/examples/value.rs
+++ b/examples/value.rs
@@ -24,7 +24,6 @@ fn main() {
     debug::render_png("value2.png", &PermutationTable::new(0), 1024, 1024, scaled_value2);
     debug::render_png("value3.png", &PermutationTable::new(0), 1024, 1024, scaled_value3);
     debug::render_png("value4.png", &PermutationTable::new(0), 1024, 1024, scaled_value4);
-    println!("\nGenerated value2.png, value3.png and value4.png");
 }
 
 fn scaled_value2(perm_table: &PermutationTable, point: &Point2<f64>) -> f64 {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+where_trailing_comma = true
+reorder_imports = true
+match_block_trailing_comma = true

--- a/src/brownian.rs
+++ b/src/brownian.rs
@@ -14,7 +14,7 @@
 
 use num_traits::Float;
 
-use {math, PermutationTable};
+use {PermutationTable, math};
 use {GenFn2, GenFn3, GenFn4};
 use {Point2, Point3, Point4};
 
@@ -207,7 +207,7 @@ macro_rules! impl_brownian {
             pub fn apply(&self, perm_table: &PermutationTable, point: &$Point<T>) -> T {
                 // Fixes weird accumulation at the origin.
                 //
-                // The chosen offset is the square root of 3. An irrational 
+                // The chosen offset is the square root of 3. An irrational
                 // number is chosen so grid-aligned noise values don't coincide
                 // with each other.
                 const OFFSET: f64 = 1.73205080756887;
@@ -237,20 +237,22 @@ impl_brownian! { Brownian3, GenFn3, Point3, math::map3 }
 impl_brownian! { Brownian4, GenFn4, Point4, math::map4 }
 
 #[cfg(rust_unstable)]
-impl<'a, 'b, T, F> Fn(&'a PermutationTable, &'b Point2<T>) for Brownian2<T, F> where
-    T: Float,
-    F: GenFn2<T>,
+impl<'a, 'b, T, F> Fn(&'a PermutationTable, &'b Point2<T>) for Brownian2<T, F>
+    where T: Float,
+          F: GenFn2<T>,
 {
     /// Applies the brownian noise function for the supplied permutation table and point.
-    extern "rust-call" fn call(&self, (perm_table, point): (&'a PermutationTable, &'b Point2<T>)) -> T {
+    extern "rust-call" fn call(&self,
+                               (perm_table, point): (&'a PermutationTable, &'b Point2<T>))
+                               -> T {
         self.apply(perm_table, point)
     }
 }
 
 #[cfg(rust_unstable)]
-impl<'a, 'b, T, F> FnMut(&'a PermutationTable, &'b Point2<T>) for Brownian2<T, F> where
-    T: Float,
-    F: GenFn2<T>,
+impl<'a, 'b, T, F> FnMut(&'a PermutationTable, &'b Point2<T>) for Brownian2<T, F>
+    where T: Float,
+          F: GenFn2<T>,
 {
     extern "rust-call" fn call_mut(&mut self, (table, point): (&'a Seed, &'b Point2<T>)) -> T {
         self.call((table, point))
@@ -258,9 +260,9 @@ impl<'a, 'b, T, F> FnMut(&'a PermutationTable, &'b Point2<T>) for Brownian2<T, F
 }
 
 #[cfg(rust_unstable)]
-impl<'a, 'b, T, F> FnOnce(&'a Seed, &'b Point2<T>) for Brownian2<T, F> where
-    T: Float,
-    F: GenFn2<T>,
+impl<'a, 'b, T, F> FnOnce(&'a Seed, &'b Point2<T>) for Brownian2<T, F>
+    where T: Float,
+          F: GenFn2<T>,
 {
     type Output = T;
     extern "rust-call" fn call_once(self, (seed, point): (&'a Seed, &'b Point2<T>)) -> T {
@@ -269,9 +271,9 @@ impl<'a, 'b, T, F> FnOnce(&'a Seed, &'b Point2<T>) for Brownian2<T, F> where
 }
 
 #[cfg(rust_unstable)]
-impl<'a, 'b, T, F> Fn(&'a Seed, &'b Point3<T>) for Brownian3<T, F> where
-    T: Float,
-    F: GenFn3<T>,
+impl<'a, 'b, T, F> Fn(&'a Seed, &'b Point3<T>) for Brownian3<T, F>
+    where T: Float,
+          F: GenFn3<T>,
 {
     /// Applies the brownian noise function for the supplied seed and point.
     extern "rust-call" fn call(&self, (seed, point): (&'a Seed, &'b Point3<T>)) -> T {
@@ -280,9 +282,9 @@ impl<'a, 'b, T, F> Fn(&'a Seed, &'b Point3<T>) for Brownian3<T, F> where
 }
 
 #[cfg(rust_unstable)]
-impl<'a, 'b, T, F> FnMut(&'a Seed, &'b Point3<T>) for Brownian3<T, F> where
-    T: Float,
-    F: GenFn3<T>,
+impl<'a, 'b, T, F> FnMut(&'a Seed, &'b Point3<T>) for Brownian3<T, F>
+    where T: Float,
+          F: GenFn3<T>,
 {
     extern "rust-call" fn call_mut(&mut self, (seed, point): (&'a Seed, &'b Point3<T>)) -> T {
         self.call((seed, point))
@@ -290,9 +292,9 @@ impl<'a, 'b, T, F> FnMut(&'a Seed, &'b Point3<T>) for Brownian3<T, F> where
 }
 
 #[cfg(rust_unstable)]
-impl<'a, 'b, T, F> FnOnce(&'a Seed, &'b Point3<T>) for Brownian3<T, F> where
-    T: Float,
-    F: GenFn3<T>,
+impl<'a, 'b, T, F> FnOnce(&'a Seed, &'b Point3<T>) for Brownian3<T, F>
+    where T: Float,
+          F: GenFn3<T>,
 {
     type Output = T;
     extern "rust-call" fn call_once(self, (seed, point): (&'a Seed, &'b Point3<T>)) -> T {
@@ -301,9 +303,9 @@ impl<'a, 'b, T, F> FnOnce(&'a Seed, &'b Point3<T>) for Brownian3<T, F> where
 }
 
 #[cfg(rust_unstable)]
-impl<'a, 'b, T, F> Fn(&'a Seed, &'b ::Point4<T>) for Brownian4<T, F> where
-    T: Float,
-    F: GenFn4<T>,
+impl<'a, 'b, T, F> Fn(&'a Seed, &'b ::Point4<T>) for Brownian4<T, F>
+    where T: Float,
+          F: GenFn4<T>,
 {
     /// Applies the brownian noise function for the supplied seed and point.
     extern "rust-call" fn call(&self, (seed, point): (&'a Seed, &'b Point4<T>)) -> T {
@@ -312,9 +314,9 @@ impl<'a, 'b, T, F> Fn(&'a Seed, &'b ::Point4<T>) for Brownian4<T, F> where
 }
 
 #[cfg(rust_unstable)]
-impl<'a, 'b, T, F> FnMut(&'a Seed, &'b Point4<T>) for Brownian4<T, F> where
-    T: Float,
-    F: GenFn4<T>,
+impl<'a, 'b, T, F> FnMut(&'a Seed, &'b Point4<T>) for Brownian4<T, F>
+    where T: Float,
+          F: GenFn4<T>,
 {
     extern "rust-call" fn call_mut(&mut self, (seed, point): (&'a Seed, &'b Point4<T>)) -> T {
         self.call((seed, point))
@@ -322,9 +324,9 @@ impl<'a, 'b, T, F> FnMut(&'a Seed, &'b Point4<T>) for Brownian4<T, F> where
 }
 
 #[cfg(rust_unstable)]
-impl<'a, 'b, T, F> FnOnce(&'a Seed, &'b Point4<T>) for Brownian4<T, F> where
-    T: Float,
-    F: GenFn4<T>,
+impl<'a, 'b, T, F> FnOnce(&'a Seed, &'b Point4<T>) for Brownian4<T, F>
+    where T: Float,
+          F: GenFn4<T>,
 {
     type Output = T;
     extern "rust-call" fn call_once(self, (seed, point): (&'a Seed, &'b Point4<T>)) -> T {

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -12,29 +12,44 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use {math, PermutationTable};
+use {PermutationTable, math};
 use num_traits::Float;
 
 #[inline(always)]
-fn get_cell_point2<T: Float>(perm_table: &PermutationTable, cell: math::Point2<T>) -> math::Point2<T> {
+fn get_cell_point2<T: Float>(perm_table: &PermutationTable,
+                             cell: math::Point2<T>)
+                             -> math::Point2<T> {
     let val = perm_table.get2(math::cast2::<_, i64>(cell));
-    math::add2(cell, math::mul2(math::cast2([val & 0x0F, (val & 0xF0) >> 4]), math::cast(1.0 / 15.0)))
+    math::add2(cell,
+               math::mul2(math::cast2([val & 0x0F, (val & 0xF0) >> 4]),
+                          math::cast(1.0 / 15.0)))
 }
 
 #[inline(always)]
-fn get_cell_point3<T: Float>(perm_table: &PermutationTable, cell: math::Point3<T>) -> math::Point3<T> {
+fn get_cell_point3<T: Float>(perm_table: &PermutationTable,
+                             cell: math::Point3<T>)
+                             -> math::Point3<T> {
     let cell_int = math::cast3::<_, i64>(cell);
     let val1 = perm_table.get3(cell_int);
     let val2 = perm_table.get3([cell_int[0], cell_int[1], cell_int[2] + 128]);
-    math::add3(cell, math::mul3(math::cast3([val1 & 0x0F, (val1 & 0xF0) >> 4, val2 & 0x0F]), math::cast(1.0 / 15.0)))
+    math::add3(cell,
+               math::mul3(math::cast3([val1 & 0x0F, (val1 & 0xF0) >> 4, val2 & 0x0F]),
+                          math::cast(1.0 / 15.0)))
 }
 
 #[inline(always)]
-fn get_cell_point4<T: Float>(perm_table: &PermutationTable, cell: math::Point4<T>) -> math::Point4<T> {
+fn get_cell_point4<T: Float>(perm_table: &PermutationTable,
+                             cell: math::Point4<T>)
+                             -> math::Point4<T> {
     let cell_int = math::cast4::<_, i64>(cell);
     let val1 = perm_table.get4(cell_int);
     let val2 = perm_table.get4([cell_int[0], cell_int[1], cell_int[2], cell_int[3] + 128]);
-    math::add4(cell, math::mul4(math::cast4([val1 & 0x0F, (val1 & 0xF0) >> 4, val2 & 0x0F, (val2 & 0xF0) >> 4]), math::cast(1.0 / 15.0)))
+    math::add4(cell,
+               math::mul4(math::cast4([val1 & 0x0F,
+                                       (val1 & 0xF0) >> 4,
+                                       val2 & 0x0F,
+                                       (val2 & 0xF0) >> 4]),
+                          math::cast(1.0 / 15.0)))
 }
 
 #[inline(always)]
@@ -74,11 +89,12 @@ pub fn range_manhattan4<T: Float>(p1: math::Point4<T>, p2: math::Point4<T>) -> T
 }
 
 #[inline(always)]
+#[cfg_attr(rustfmt, rustfmt_skip)]
 pub fn get_vec2<T: Float>(index: usize) -> math::Point2<T> {
-    let length = math::cast::<_,T>((index & 0xF8) >> 3) * math::cast(0.5 / 31.0);
+    let length = math::cast::<_, T>((index & 0xF8) >> 3) * math::cast(0.5 / 31.0);
     let diag = length * math::cast(0.70710678118);
     let one = length;
-    let zero: T = math::cast(0.0);
+    let zero = T::zero();
     match index & 0x07 {
         0 => [ diag,  diag],
         1 => [ diag, -diag],
@@ -93,11 +109,12 @@ pub fn get_vec2<T: Float>(index: usize) -> math::Point2<T> {
 }
 
 #[inline(always)]
+#[cfg_attr(rustfmt, rustfmt_skip)]
 pub fn get_vec3<T: Float>(index: usize) -> math::Point3<T> {
-    let length = math::cast::<_,T>((index & 0xE0) >> 5) * math::cast(0.5 / 7.0);
+    let length = math::cast::<_, T>((index & 0xE0) >> 5) * math::cast(0.5 / 7.0);
     let diag = length * math::cast(0.70710678118f32);
     let one = length;
-    let zero = math::cast(0.0);
+    let zero = T::zero();
     match index % 18 {
         0  => [ diag,  diag,  zero],
         1  => [ diag, -diag,  zero],
@@ -122,10 +139,11 @@ pub fn get_vec3<T: Float>(index: usize) -> math::Point3<T> {
 }
 
 #[inline(always)]
+#[cfg_attr(rustfmt, rustfmt_skip)]
 pub fn get_vec4<T: Float>(index: usize) -> math::Point4<T> {
-    let length = math::cast::<_,T>((index & 0xE0) >> 5) * math::cast(0.5 / 7.0);
+    let length = math::cast::<_, T>((index & 0xE0) >> 5) * math::cast(0.5 / 7.0);
     let diag = length * math::cast(0.57735026919);
-    let zero = math::cast(0.0);
+    let zero = T::zero();
     match index % 32 {
         0  => [ diag,  diag,  diag,  zero],
         1  => [ diag, -diag,  diag,  zero],
@@ -164,19 +182,25 @@ pub fn get_vec4<T: Float>(index: usize) -> math::Point4<T> {
 }
 
 #[inline(always)]
-fn cell2_seed<T, F>(perm_table: &PermutationTable, point: &math::Point2<T>, range_func: F) -> (math::Point2<i64>, math::Point2<T>, T)
-    where T: Float, F: Fn(math::Point2<T>, math::Point2<T>) -> T
+fn cell2_seed<T, F>(perm_table: &PermutationTable,
+                    point: &math::Point2<T>,
+                    range_func: F)
+                    -> (math::Point2<i64>, math::Point2<T>, T)
+    where T: Float,
+          F: Fn(math::Point2<T>, math::Point2<T>) -> T,
 {
     #[inline(always)]
-    fn get_point<T: Float>(perm_table: &PermutationTable, whole: math::Point2<i64>) -> math::Point2<T> {
+    fn get_point<T: Float>(perm_table: &PermutationTable,
+                           whole: math::Point2<i64>)
+                           -> math::Point2<T> {
         math::add2(get_vec2(perm_table.get2(whole)), math::cast2::<_, T>(whole))
     }
 
     let half: T = math::cast(0.5);
 
-    let floored = math::map2(*point, Float::floor);
-    let whole   = math::map2(floored, math::cast::<_, i64>);
-    let frac    = math::sub2(*point, floored);
+    let floored = math::map2(*point, T::floor);
+    let whole = math::map2(floored, math::cast::<_, i64>);
+    let frac = math::sub2(*point, floored);
 
     let x_half = frac[0] > half;
     let y_half = frac[1] > half;
@@ -205,35 +229,48 @@ fn cell2_seed<T, F>(perm_table: &PermutationTable, point: &math::Point2<T>, rang
         }
     );
 
-    if x_range < range { test_point![far[0], near[1]]; }
-    if y_range < range { test_point![near[0], far[1]]; }
+    if x_range < range {
+        test_point![far[0], near[1]];
+    }
+    if y_range < range {
+        test_point![near[0], far[1]];
+    }
 
-    if x_range < range && y_range < range { test_point![far[0], far[1]]; }
+    if x_range < range && y_range < range {
+        test_point![far[0], far[1]];
+    }
 
     (seed_cell, seed_point, range)
 }
 
 #[inline(always)]
-fn cell3_seed<T, F>(perm_table: &PermutationTable, point: &math::Point3<T>, range_func: F) -> (math::Point3<i64>, math::Point3<T>, T)
-    where T: Float, F: Fn(math::Point3<T>, math::Point3<T>) -> T
+fn cell3_seed<T, F>(perm_table: &PermutationTable,
+                    point: &math::Point3<T>,
+                    range_func: F)
+                    -> (math::Point3<i64>, math::Point3<T>, T)
+    where T: Float,
+          F: Fn(math::Point3<T>, math::Point3<T>) -> T,
 {
     #[inline(always)]
-    fn get_point<T: Float>(perm_table: &PermutationTable, whole: math::Point3<i64>) -> math::Point3<T> {
+    fn get_point<T: Float>(perm_table: &PermutationTable,
+                           whole: math::Point3<i64>)
+                           -> math::Point3<T> {
         math::add3(get_vec3(perm_table.get3(whole)), math::cast3::<_, T>(whole))
     }
 
     let half: T = math::cast(0.5);
 
-    let floored = math::map3(*point, Float::floor);
-    let whole   = math::map3(floored, math::cast::<_, i64>);
-    let frac    = math::sub3(*point, floored);
+    let floored = math::map3(*point, T::floor);
+    let whole = math::map3(floored, math::cast::<_, i64>);
+    let frac = math::sub3(*point, floored);
 
     let x_half = frac[0] > half;
     let y_half = frac[1] > half;
     let z_half = frac[2] > half;
 
     let near = [whole[0] + (x_half as i64), whole[1] + (y_half as i64), whole[2] + (z_half as i64)];
-    let far = [whole[0] + (!x_half as i64), whole[1] + (!y_half as i64), whole[2] + (!z_half as i64)];
+    let far =
+        [whole[0] + (!x_half as i64), whole[1] + (!y_half as i64), whole[2] + (!z_half as i64)];
 
     let mut seed_cell = near;
     let mut seed_point = get_point(perm_table, near);
@@ -257,41 +294,67 @@ fn cell3_seed<T, F>(perm_table: &PermutationTable, point: &math::Point3<T>, rang
         }
     );
 
-    if x_range < range { test_point![far[0], near[1], near[2]]; }
-    if y_range < range { test_point![near[0], far[1], near[2]]; }
-    if z_range < range { test_point![near[0], near[1], far[2]]; }
+    if x_range < range {
+        test_point![far[0], near[1], near[2]];
+    }
+    if y_range < range {
+        test_point![near[0], far[1], near[2]];
+    }
+    if z_range < range {
+        test_point![near[0], near[1], far[2]];
+    }
 
-    if x_range < range && y_range < range { test_point![far[0], far[1], near[2]]; }
-    if x_range < range && z_range < range { test_point![far[0], near[1], far[2]]; }
-    if y_range < range && z_range < range { test_point![near[0], far[1], far[2]]; }
+    if x_range < range && y_range < range {
+        test_point![far[0], far[1], near[2]];
+    }
+    if x_range < range && z_range < range {
+        test_point![far[0], near[1], far[2]];
+    }
+    if y_range < range && z_range < range {
+        test_point![near[0], far[1], far[2]];
+    }
 
-    if x_range < range && y_range < range && z_range < range { test_point![far[0], far[1], far[2]]; }
+    if x_range < range && y_range < range && z_range < range {
+        test_point![far[0], far[1], far[2]];
+    }
 
     (seed_cell, seed_point, range)
 }
 
 #[inline(always)]
-fn cell4_seed<T, F>(perm_table: &PermutationTable, point: &math::Point4<T>, range_func: F) -> (math::Point4<i64>, math::Point4<T>, T)
-    where T: Float, F: Fn(math::Point4<T>, math::Point4<T>) -> T
+fn cell4_seed<T, F>(perm_table: &PermutationTable,
+                    point: &math::Point4<T>,
+                    range_func: F)
+                    -> (math::Point4<i64>, math::Point4<T>, T)
+    where T: Float,
+          F: Fn(math::Point4<T>, math::Point4<T>) -> T,
 {
     #[inline(always)]
-    fn get_point<T: Float>(perm_table: &PermutationTable, whole: math::Point4<i64>) -> math::Point4<T> {
+    fn get_point<T: Float>(perm_table: &PermutationTable,
+                           whole: math::Point4<i64>)
+                           -> math::Point4<T> {
         math::add4(get_vec4(perm_table.get4(whole)), math::cast4::<_, T>(whole))
     }
 
     let half: T = math::cast(0.5);
 
-    let floored = math::map4(*point, Float::floor);
-    let whole   = math::map4(floored, math::cast::<_, i64>);
-    let frac    = math::sub4(*point, floored);
+    let floored = math::map4(*point, T::floor);
+    let whole = math::map4(floored, math::cast::<_, i64>);
+    let frac = math::sub4(*point, floored);
 
     let x_half = frac[0] > half;
     let y_half = frac[1] > half;
     let z_half = frac[2] > half;
     let w_half = frac[3] > half;
 
-    let near = [whole[0] + (x_half as i64), whole[1] + (y_half as i64), whole[2] + (z_half as i64), whole[3] + (w_half as i64)];
-    let far = [whole[0] + (!x_half as i64), whole[1] + (!y_half as i64), whole[2] + (!z_half as i64), whole[3] + (!w_half as i64)];
+    let near = [whole[0] + (x_half as i64),
+                whole[1] + (y_half as i64),
+                whole[2] + (z_half as i64),
+                whole[3] + (w_half as i64)];
+    let far = [whole[0] + (!x_half as i64),
+               whole[1] + (!y_half as i64),
+               whole[2] + (!z_half as i64),
+               whole[3] + (!w_half as i64)];
 
     let mut seed_cell = near;
     let mut seed_point = get_point(perm_table, near);
@@ -316,63 +379,113 @@ fn cell4_seed<T, F>(perm_table: &PermutationTable, point: &math::Point4<T>, rang
         }
     );
 
-    if x_range < range { test_point![far[0], near[1], near[2], near[3]]; }
-    if y_range < range { test_point![near[0], far[1], near[2], near[3]]; }
-    if z_range < range { test_point![near[0], near[1], far[2], near[3]]; }
-    if w_range < range { test_point![near[0], near[1], near[2], far[3]]; }
+    if x_range < range {
+        test_point![far[0], near[1], near[2], near[3]];
+    }
+    if y_range < range {
+        test_point![near[0], far[1], near[2], near[3]];
+    }
+    if z_range < range {
+        test_point![near[0], near[1], far[2], near[3]];
+    }
+    if w_range < range {
+        test_point![near[0], near[1], near[2], far[3]];
+    }
 
-    if x_range < range && y_range < range { test_point![far[0], far[1], near[2], near[3]]; }
-    if x_range < range && z_range < range { test_point![far[0], near[1], far[2], near[3]]; }
-    if x_range < range && w_range < range { test_point![far[0], near[1], near[2], far[3]]; }
-    if y_range < range && z_range < range { test_point![near[0], far[1], far[2], near[3]]; }
-    if y_range < range && w_range < range { test_point![near[0], far[1], near[2], far[3]]; }
-    if z_range < range && w_range < range { test_point![near[0], near[1], far[2], far[3]]; }
+    if x_range < range && y_range < range {
+        test_point![far[0], far[1], near[2], near[3]];
+    }
+    if x_range < range && z_range < range {
+        test_point![far[0], near[1], far[2], near[3]];
+    }
+    if x_range < range && w_range < range {
+        test_point![far[0], near[1], near[2], far[3]];
+    }
+    if y_range < range && z_range < range {
+        test_point![near[0], far[1], far[2], near[3]];
+    }
+    if y_range < range && w_range < range {
+        test_point![near[0], far[1], near[2], far[3]];
+    }
+    if z_range < range && w_range < range {
+        test_point![near[0], near[1], far[2], far[3]];
+    }
 
-    if x_range < range && y_range < range && z_range < range { test_point![far[0], far[1], far[2], near[3]]; }
-    if x_range < range && y_range < range && w_range < range { test_point![far[0], far[1], near[2], far[3]]; }
-    if x_range < range && z_range < range && w_range < range { test_point![far[0], near[1], far[2], far[3]]; }
-    if y_range < range && z_range < range && w_range < range { test_point![near[0], far[1], far[2], far[3]]; }
+    if x_range < range && y_range < range && z_range < range {
+        test_point![far[0], far[1], far[2], near[3]];
+    }
+    if x_range < range && y_range < range && w_range < range {
+        test_point![far[0], far[1], near[2], far[3]];
+    }
+    if x_range < range && z_range < range && w_range < range {
+        test_point![far[0], near[1], far[2], far[3]];
+    }
+    if y_range < range && z_range < range && w_range < range {
+        test_point![near[0], far[1], far[2], far[3]];
+    }
 
-    if x_range < range && y_range < range && z_range < range && w_range < range { test_point![far[0], far[1], far[2], far[3]]; }
+    if x_range < range && y_range < range && z_range < range && w_range < range {
+        test_point![far[0], far[1], far[2], far[3]];
+    }
 
     (seed_cell, seed_point, range)
 }
 
 #[inline(always)]
-pub fn cell2_seed_point<T, F>(perm_table: &PermutationTable, point: &math::Point2<T>, range_func: F) -> (math::Point2<T>, T)
-    where T: Float, F: Fn(math::Point2<T>, math::Point2<T>) -> T
+pub fn cell2_seed_point<T, F>(perm_table: &PermutationTable,
+                              point: &math::Point2<T>,
+                              range_func: F)
+                              -> (math::Point2<T>, T)
+    where T: Float,
+          F: Fn(math::Point2<T>, math::Point2<T>) -> T,
 {
     let (_, seed_point, range) = cell2_seed(perm_table, point, range_func);
     (seed_point, range)
 }
 
 #[inline(always)]
-pub fn cell2_seed_cell<T, F>(perm_table: &PermutationTable, point: &math::Point2<T>, range_func: F) -> math::Point2<i64>
-    where T: Float, F: Fn(math::Point2<T>, math::Point2<T>) -> T
+pub fn cell2_seed_cell<T, F>(perm_table: &PermutationTable,
+                             point: &math::Point2<T>,
+                             range_func: F)
+                             -> math::Point2<i64>
+    where T: Float,
+          F: Fn(math::Point2<T>, math::Point2<T>) -> T,
 {
     let (cell, _, _) = cell2_seed(perm_table, point, range_func);
     cell
 }
 
 #[inline(always)]
-pub fn cell3_seed_point<T, F>(perm_table: &PermutationTable, point: &math::Point3<T>, range_func: F) -> (math::Point3<T>, T)
-    where T: Float, F: Fn(math::Point3<T>, math::Point3<T>) -> T
+pub fn cell3_seed_point<T, F>(perm_table: &PermutationTable,
+                              point: &math::Point3<T>,
+                              range_func: F)
+                              -> (math::Point3<T>, T)
+    where T: Float,
+          F: Fn(math::Point3<T>, math::Point3<T>) -> T,
 {
     let (_, seed_point, range) = cell3_seed(perm_table, point, range_func);
     (seed_point, range)
 }
 
 #[inline(always)]
-pub fn cell3_seed_cell<T, F>(perm_table: &PermutationTable, point: &math::Point3<T>, range_func: F) -> math::Point3<i64>
-    where T: Float, F: Fn(math::Point3<T>, math::Point3<T>) -> T
+pub fn cell3_seed_cell<T, F>(perm_table: &PermutationTable,
+                             point: &math::Point3<T>,
+                             range_func: F)
+                             -> math::Point3<i64>
+    where T: Float,
+          F: Fn(math::Point3<T>, math::Point3<T>) -> T,
 {
     let (cell, _, _) = cell3_seed(perm_table, point, range_func);
     cell
 }
 
 #[inline(always)]
-pub fn cell4_seed_point<T, F>(perm_table: &PermutationTable, point: &math::Point4<T>, range_func: F) -> (math::Point4<T>, T)
-    where T: Float, F: Fn(math::Point4<T>, math::Point4<T>) -> T
+pub fn cell4_seed_point<T, F>(perm_table: &PermutationTable,
+                              point: &math::Point4<T>,
+                              range_func: F)
+                              -> (math::Point4<T>, T)
+    where T: Float,
+          F: Fn(math::Point4<T>, math::Point4<T>) -> T,
 {
     let (_, seed_point, range) = cell4_seed(perm_table, point, range_func);
     (seed_point, range)
@@ -381,6 +494,7 @@ pub fn cell4_seed_point<T, F>(perm_table: &PermutationTable, point: &math::Point
 // These would be faster if we unrolled them like in the 2D version
 // Doing that, however, increases the compile time of library users from
 // 1 second to 120 seconds which is a poor tradeoff
+#[cfg_attr(rustfmt, rustfmt_skip)]
 static CELL3_SEARCH_ORDER: [math::Point3<isize>; 26] = [
     [-1,  0,  0], [ 1,  0,  0], [ 0, -1,  0], [ 0,  1,  0], [ 0,  0, -1],
     [ 0,  0,  1], [-1, -1,  0], [-1,  1,  0], [ 1, -1,  0], [ 1,  1,  0],
@@ -390,6 +504,7 @@ static CELL3_SEARCH_ORDER: [math::Point3<isize>; 26] = [
     [ 1,  1,  1],
 ];
 
+#[cfg_attr(rustfmt, rustfmt_skip)]
 static CELL4_SEARCH_ORDER: [math::Point4<isize>; 80] = [
     [-1,  0,  0,  0], [ 1,  0,  0,  0], [ 0, -1,  0,  0], [ 0,  1,  0,  0],
     [ 0,  0, -1,  0], [ 0,  0,  1,  0], [ 0,  0,  0, -1], [ 0,  0,  0,  1],
@@ -414,27 +529,35 @@ static CELL4_SEARCH_ORDER: [math::Point4<isize>; 80] = [
 ];
 
 #[inline(always)]
-pub fn cell4_seed_cell<T, F>(perm_table: &PermutationTable, point: &math::Point4<T>, range_func: F) -> math::Point4<i64>
-    where T: Float, F: Fn(math::Point4<T>, math::Point4<T>) -> T
+pub fn cell4_seed_cell<T, F>(perm_table: &PermutationTable,
+                             point: &math::Point4<T>,
+                             range_func: F)
+                             -> math::Point4<i64>
+    where T: Float,
+          F: Fn(math::Point4<T>, math::Point4<T>) -> T,
 {
     let (cell, _, _) = cell4_seed(perm_table, point, range_func);
     cell
 }
 
 #[inline(always)]
-pub fn cell2_seed_2_points<T, F>(perm_table: &PermutationTable, point: &math::Point2<T>, range_func: F) -> (math::Point2<T>, T, math::Point2<T>, T)
-    where T: Float, F: Fn(math::Point2<T>, math::Point2<T>) -> T
+pub fn cell2_seed_2_points<T, F>(perm_table: &PermutationTable,
+                                 point: &math::Point2<T>,
+                                 range_func: F)
+                                 -> (math::Point2<T>, T, math::Point2<T>, T)
+    where T: Float,
+          F: Fn(math::Point2<T>, math::Point2<T>) -> T,
 {
-    let one: T = math::cast(1.0);
-    let zero: T = math::cast(0.0);
+    let one = T::one();
+    let zero = T::zero();
 
-    let cell = math::map2(*point, Float::floor);
+    let cell = math::map2(*point, T::floor);
     let frac = math::sub2(*point, cell);
 
     let mut seed_point0 = get_cell_point2(perm_table, cell);
     let mut seed_point1 = [one, one];
     let mut range0 = range_func(*point, seed_point0);
-    let mut range1 = Float::max_value();
+    let mut range1 = T::max_value();
 
     // Distance squared for the previous, current, and next cells in each dimension
     let dx2 = [frac[0] * frac[0], zero, (one - frac[0]) * (one - frac[0])];
@@ -447,7 +570,8 @@ pub fn cell2_seed_2_points<T, F>(perm_table: &PermutationTable, point: &math::Po
                 let y_range = dy2[($y + 1) as usize];
 
                 if x_range + y_range < range1 {
-                    let cur_point = get_cell_point2(perm_table, math::add2(cell, math::cast2([$x, $y])));
+                    let cur_point = get_cell_point2(perm_table, math::add2(cell,
+                        math::cast2([$x, $y])));
                     let cur_range = range_func(*point, cur_point);
                     if cur_range < range0 {
                         range1 = range0;
@@ -479,19 +603,23 @@ pub fn cell2_seed_2_points<T, F>(perm_table: &PermutationTable, point: &math::Po
 }
 
 #[inline(always)]
-pub fn cell3_seed_2_points<T, F>(perm_table: &PermutationTable, point: &math::Point3<T>, range_func: F) -> (math::Point3<T>, T, math::Point3<T>, T)
-    where T: Float, F: Fn(math::Point3<T>, math::Point3<T>) -> T
+pub fn cell3_seed_2_points<T, F>(perm_table: &PermutationTable,
+                                 point: &math::Point3<T>,
+                                 range_func: F)
+                                 -> (math::Point3<T>, T, math::Point3<T>, T)
+    where T: Float,
+          F: Fn(math::Point3<T>, math::Point3<T>) -> T,
 {
-    let one: T = math::cast(1.0);
-    let zero: T = math::cast(0.0);
+    let one = T::one();
+    let zero = T::zero();
 
-    let cell = math::map3(*point, Float::floor);
+    let cell = math::map3(*point, T::floor);
     let frac = math::sub3(*point, cell);
 
     let mut seed_point0 = get_cell_point3(perm_table, cell);
     let mut seed_point1 = [one, one, one];
     let mut range0 = range_func(*point, seed_point0);
-    let mut range1 = Float::max_value();
+    let mut range1 = T::max_value();
 
     // Distance squared for the previous, current, and next cells in each dimension
     let dx2 = [frac[0] * frac[0], zero, (one - frac[0]) * (one - frac[0])];
@@ -522,19 +650,23 @@ pub fn cell3_seed_2_points<T, F>(perm_table: &PermutationTable, point: &math::Po
 }
 
 #[inline(always)]
-pub fn cell4_seed_2_points<T, F>(perm_table: &PermutationTable, point: &math::Point4<T>, range_func: F) -> (math::Point4<T>, T, math::Point4<T>, T)
-    where T: Float, F: Fn(math::Point4<T>, math::Point4<T>) -> T
+pub fn cell4_seed_2_points<T, F>(perm_table: &PermutationTable,
+                                 point: &math::Point4<T>,
+                                 range_func: F)
+                                 -> (math::Point4<T>, T, math::Point4<T>, T)
+    where T: Float,
+          F: Fn(math::Point4<T>, math::Point4<T>) -> T,
 {
-    let one: T = math::cast(1.0);
-    let zero: T = math::cast(0.0);
+    let one = T::one();
+    let zero = T::zero();
 
-    let cell = math::map4(*point, Float::floor);
+    let cell = math::map4(*point, T::floor);
     let frac = math::sub4(*point, cell);
 
     let mut seed_point0 = get_cell_point4(perm_table, cell);
     let mut seed_point1 = [one, one, one, one];
     let mut range0 = range_func(*point, seed_point0);
-    let mut range1 = Float::max_value();
+    let mut range1 = T::max_value();
 
     // Distance squared for the previous, current, and next cells in each dimension
     let dx2 = [frac[0] * frac[0], zero, (one - frac[0]) * (one - frac[0])];
@@ -598,17 +730,17 @@ pub fn cell4_range_inv<T: Float>(perm_table: &PermutationTable, point: &math::Po
 
 pub fn cell2_value<T: Float>(perm_table: &PermutationTable, point: &math::Point2<T>) -> T {
     let cell = cell2_seed_cell(perm_table, point, range_sqr_euclidian2);
-    math::cast::<_,T>(perm_table.get2(cell)) * math::cast(1.0 / 255.0)
+    math::cast::<_, T>(perm_table.get2(cell)) * math::cast(1.0 / 255.0)
 }
 
 pub fn cell3_value<T: Float>(perm_table: &PermutationTable, point: &math::Point3<T>) -> T {
     let cell = cell3_seed_cell(perm_table, point, range_sqr_euclidian3);
-    math::cast::<_,T>(perm_table.get3(cell)) * math::cast(1.0 / 255.0)
+    math::cast::<_, T>(perm_table.get3(cell)) * math::cast(1.0 / 255.0)
 }
 
 pub fn cell4_value<T: Float>(perm_table: &PermutationTable, point: &math::Point4<T>) -> T {
     let cell = cell4_seed_cell(perm_table, point, range_sqr_euclidian4);
-    math::cast::<_,T>(perm_table.get4(cell)) * math::cast(1.0 / 255.0)
+    math::cast::<_, T>(perm_table.get4(cell)) * math::cast(1.0 / 255.0)
 }
 
 pub fn cell2_manhattan<T: Float>(perm_table: &PermutationTable, point: &math::Point2<T>) -> T {
@@ -641,17 +773,23 @@ pub fn cell4_manhattan_inv<T: Float>(perm_table: &PermutationTable, point: &math
     range2 - range1
 }
 
-pub fn cell2_manhattan_value<T: Float>(perm_table: &PermutationTable, point: &math::Point2<T>) -> T {
+pub fn cell2_manhattan_value<T: Float>(perm_table: &PermutationTable,
+                                       point: &math::Point2<T>)
+                                       -> T {
     let cell = cell2_seed_cell(perm_table, point, range_manhattan2);
-    math::cast::<_,T>(perm_table.get2(cell)) * math::cast(1.0 / 255.0)
+    math::cast::<_, T>(perm_table.get2(cell)) * math::cast(1.0 / 255.0)
 }
 
-pub fn cell3_manhattan_value<T: Float>(perm_table: &PermutationTable, point: &math::Point3<T>) -> T {
+pub fn cell3_manhattan_value<T: Float>(perm_table: &PermutationTable,
+                                       point: &math::Point3<T>)
+                                       -> T {
     let cell = cell3_seed_cell(perm_table, point, range_manhattan3);
-    math::cast::<_,T>(perm_table.get3(cell)) * math::cast(1.0 / 255.0)
+    math::cast::<_, T>(perm_table.get3(cell)) * math::cast(1.0 / 255.0)
 }
 
-pub fn cell4_manhattan_value<T: Float>(perm_table: &PermutationTable, point: &math::Point4<T>) -> T {
+pub fn cell4_manhattan_value<T: Float>(perm_table: &PermutationTable,
+                                       point: &math::Point4<T>)
+                                       -> T {
     let cell = cell4_seed_cell(perm_table, point, range_manhattan4);
-    math::cast::<_,T>(perm_table.get4(cell)) * math::cast(1.0 / 255.0)
+    math::cast::<_, T>(perm_table.get4(cell)) * math::cast(1.0 / 255.0)
 }

--- a/src/gradient.rs
+++ b/src/gradient.rs
@@ -17,6 +17,7 @@ use num_traits::Float;
 use math;
 
 #[inline(always)]
+#[cfg_attr(rustfmt, rustfmt_skip)]
 pub fn get2<T: Float>(index: usize) -> math::Vector2<T> {
     let zero = T::zero();
     let one = T::one();
@@ -37,6 +38,7 @@ pub fn get2<T: Float>(index: usize) -> math::Vector2<T> {
 }
 
 #[inline(always)]
+#[cfg_attr(rustfmt, rustfmt_skip)]
 pub fn get3<T: Float>(index: usize) -> math::Vector3<T> {
     let zero = T::zero();
     // Vectors are combinations of -1, 0, and 1, precompute the normalized elements
@@ -82,6 +84,7 @@ pub fn get3<T: Float>(index: usize) -> math::Vector3<T> {
 }
 
 #[inline(always)]
+#[cfg_attr(rustfmt, rustfmt_skip)]
 pub fn get4<T: Float>(index: usize) -> math::Vector4<T> {
     let zero = T::zero();
     // Vectors are combinations of -1, 0, and 1, precompute the normalized elements

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,6 @@ pub trait GenFn3<T>: Fn(&PermutationTable, &Point3<T>) -> T {}
 /// ```
 pub trait GenFn4<T>: Fn(&PermutationTable, &Point4<T>) -> T {}
 
-impl<T, F> GenFn2<T> for F where F: Fn(&PermutationTable, &Point2<T>) -> T {}
-impl<T, F> GenFn3<T> for F where F: Fn(&PermutationTable, &Point3<T>) -> T {}
-impl<T, F> GenFn4<T> for F where F: Fn(&PermutationTable, &Point4<T>) -> T {}
+impl<T, F> GenFn2<T> for F where F: Fn(&PermutationTable, &Point2<T>) -> T, {}
+impl<T, F> GenFn3<T> for F where F: Fn(&PermutationTable, &Point3<T>) -> T, {}
+impl<T, F> GenFn4<T> for F where F: Fn(&PermutationTable, &Point4<T>) -> T, {}

--- a/src/math.rs
+++ b/src/math.rs
@@ -16,7 +16,7 @@
 //! implement super-complex noise stuff.
 
 use num_traits::{self, Float, NumCast};
-use std::ops::{Add, Sub, Mul};
+use std::ops::{Add, Mul, Sub};
 
 /// Cast a numeric type without having to unwrap - we don't expect any overflow
 /// errors...
@@ -25,7 +25,9 @@ pub fn cast<T: NumCast, U: NumCast>(x: T) -> U {
 }
 
 /// Raises the number to the power of `4`
-pub fn pow4<T: Float>(x: T) -> T { x * x * x * x }
+pub fn pow4<T: Float>(x: T) -> T {
+    x * x * x * x
+}
 
 /// A 2-dimensional point. This is a fixed sized array, so should be compatible
 /// with most linear algebra libraries.
@@ -46,72 +48,171 @@ pub type Vector3<T> = [T; 3];
 /// A 4-dimensional vector, for internal use.
 pub type Vector4<T> = [T; 4];
 
-pub fn map2<T: Copy, U, F: Fn(T) -> U>(a: Vector2<T>, f: F) -> Vector2<U> {
+pub fn map2<T, U, F>(a: Vector2<T>, f: F) -> Vector2<U>
+    where T: Copy,
+          F: Fn(T) -> U,
+{
     let (ax, ay) = (a[0], a[1]);
     [f(ax), f(ay)]
 }
-pub fn map3<T: Copy, U, F: Fn(T) -> U>(a: Vector3<T>, f: F) -> Vector3<U> {
+pub fn map3<T, U, F>(a: Vector3<T>, f: F) -> Vector3<U>
+    where T: Copy,
+          F: Fn(T) -> U,
+{
     let (ax, ay, az) = (a[0], a[1], a[2]);
     [f(ax), f(ay), f(az)]
 }
-pub fn map4<T: Copy, U, F: Fn(T) -> U>(a: Vector4<T>, f: F) -> Vector4<U> {
+pub fn map4<T, U, F>(a: Vector4<T>, f: F) -> Vector4<U>
+    where T: Copy,
+          F: Fn(T) -> U,
+{
     let (ax, ay, az, aw) = (a[0], a[1], a[2], a[3]);
     [f(ax), f(ay), f(az), f(aw)]
 }
 
-pub fn zip_with2<T: Copy, U: Copy, V, F: Fn(T, U) -> V>(a: Vector2<T>, b: Vector2<U>, f: F) -> Vector2<V> {
+pub fn zip_with2<T, U, V, F>(a: Vector2<T>, b: Vector2<U>, f: F) -> Vector2<V>
+    where T: Copy,
+          U: Copy,
+          F: Fn(T, U) -> V,
+{
     let (ax, ay) = (a[0], a[1]);
     let (bx, by) = (b[0], b[1]);
     [f(ax, bx), f(ay, by)]
 }
-pub fn zip_with3<T: Copy, U: Copy, V, F: Fn(T, U) -> V>(a: Vector3<T>, b: Vector3<U>, f: F) -> Vector3<V> {
+pub fn zip_with3<T, U, V, F>(a: Vector3<T>, b: Vector3<U>, f: F) -> Vector3<V>
+    where T: Copy,
+          U: Copy,
+          F: Fn(T, U) -> V,
+{
     let (ax, ay, az) = (a[0], a[1], a[2]);
     let (bx, by, bz) = (b[0], b[1], b[2]);
     [f(ax, bx), f(ay, by), f(az, bz)]
 }
-pub fn zip_with4<T: Copy, U: Copy, V, F: Fn(T, U) -> V>(a: Vector4<T>, b: Vector4<U>, f: F) -> Vector4<V> {
+pub fn zip_with4<T, U, V, F>(a: Vector4<T>, b: Vector4<U>, f: F) -> Vector4<V>
+    where T: Copy,
+          U: Copy,
+          F: Fn(T, U) -> V,
+{
     let (ax, ay, az, aw) = (a[0], a[1], a[2], a[3]);
     let (bx, by, bz, bw) = (b[0], b[1], b[2], b[3]);
     [f(ax, bx), f(ay, by), f(az, bz), f(aw, bw)]
 }
 
-pub fn fold2<T: Copy, F: Fn(T, T) -> T>(a: Vector2<T>, f: F) -> T {
+pub fn fold2<T, F>(a: Vector2<T>, f: F) -> T
+    where T: Copy,
+          F: Fn(T, T) -> T,
+{
     let (ax, ay) = (a[0], a[1]);
     f(ax, ay)
 }
-pub fn fold3<T: Copy, F: Fn(T, T) -> T>(a: Vector3<T>, f: F) -> T {
+pub fn fold3<T, F>(a: Vector3<T>, f: F) -> T
+    where T: Copy,
+          F: Fn(T, T) -> T,
+{
     let (ax, ay, az) = (a[0], a[1], a[2]);
     f(f(ax, ay), az)
 }
-pub fn fold4<T: Copy, F: Fn(T, T) -> T>(a: Vector4<T>, f: F) -> T {
+pub fn fold4<T, F>(a: Vector4<T>, f: F) -> T
+    where T: Copy,
+          F: Fn(T, T) -> T,
+{
     let (ax, ay, az, aw) = (a[0], a[1], a[2], a[3]);
     f(f(f(ax, ay), az), aw)
 }
 
-pub fn add2<T: Copy + Add<T, Output = T>>(a: Point2<T>, b: Vector2<T>) -> Point2<T> { zip_with2(a, b, Add::add) }
-pub fn add3<T: Copy + Add<T, Output = T>>(a: Point3<T>, b: Vector3<T>) -> Point3<T> { zip_with3(a, b, Add::add) }
-pub fn add4<T: Copy + Add<T, Output = T>>(a: Point4<T>, b: Vector4<T>) -> Point4<T> { zip_with4(a, b, Add::add) }
+pub fn add2<T>(a: Point2<T>, b: Vector2<T>) -> Point2<T>
+    where T: Copy + Add<T, Output = T>,
+{
+    zip_with2(a, b, Add::add)
+}
+pub fn add3<T>(a: Point3<T>, b: Vector3<T>) -> Point3<T>
+    where T: Copy + Add<T, Output = T>,
+{
+    zip_with3(a, b, Add::add)
+}
+pub fn add4<T>(a: Point4<T>, b: Vector4<T>) -> Point4<T>
+    where T: Copy + Add<T, Output = T>,
+{
+    zip_with4(a, b, Add::add)
+}
 
-pub fn sub2<T: Copy + Sub<T, Output = T>>(a: Point2<T>, b: Point2<T>) -> Vector2<T> { zip_with2(a, b, Sub::sub) }
-pub fn sub3<T: Copy + Sub<T, Output = T>>(a: Point3<T>, b: Point3<T>) -> Vector3<T> { zip_with3(a, b, Sub::sub) }
-pub fn sub4<T: Copy + Sub<T, Output = T>>(a: Point4<T>, b: Point4<T>) -> Vector4<T> { zip_with4(a, b, Sub::sub) }
+pub fn sub2<T>(a: Point2<T>, b: Point2<T>) -> Vector2<T>
+    where T: Copy + Sub<T, Output = T>,
+{
+    zip_with2(a, b, Sub::sub)
+}
+pub fn sub3<T>(a: Point3<T>, b: Point3<T>) -> Vector3<T>
+    where T: Copy + Sub<T, Output = T>,
+{
+    zip_with3(a, b, Sub::sub)
+}
+pub fn sub4<T>(a: Point4<T>, b: Point4<T>) -> Vector4<T>
+    where T: Copy + Sub<T, Output = T>,
+{
+    zip_with4(a, b, Sub::sub)
+}
 
-pub fn mul2<T: Copy + Mul<T, Output = T> + Copy>(a: Vector2<T>, b: T) -> Vector2<T> { zip_with2(a, const2(b), Mul::mul) }
-pub fn mul3<T: Copy + Mul<T, Output = T> + Copy>(a: Vector3<T>, b: T) -> Vector3<T> { zip_with3(a, const3(b), Mul::mul) }
-pub fn mul4<T: Copy + Mul<T, Output = T> + Copy>(a: Vector4<T>, b: T) -> Vector4<T> { zip_with4(a, const4(b), Mul::mul) }
+pub fn mul2<T>(a: Vector2<T>, b: T) -> Vector2<T>
+    where T: Copy + Mul<T, Output = T>,
+{
+    zip_with2(a, const2(b), Mul::mul)
+}
+pub fn mul3<T>(a: Vector3<T>, b: T) -> Vector3<T>
+    where T: Copy + Mul<T, Output = T>,
+{
+    zip_with3(a, const3(b), Mul::mul)
+}
+pub fn mul4<T>(a: Vector4<T>, b: T) -> Vector4<T>
+    where T: Copy + Mul<T, Output = T>,
+{
+    zip_with4(a, const4(b), Mul::mul)
+}
 
-pub fn dot2<T: Float>(a: Vector2<T>, b: Vector2<T>) -> T { fold2(zip_with2(a, b, Mul::mul), Add::add) }
-pub fn dot3<T: Float>(a: Vector3<T>, b: Vector3<T>) -> T { fold3(zip_with3(a, b, Mul::mul), Add::add) }
-pub fn dot4<T: Float>(a: Vector4<T>, b: Vector4<T>) -> T { fold4(zip_with4(a, b, Mul::mul), Add::add) }
+pub fn dot2<T: Float>(a: Vector2<T>, b: Vector2<T>) -> T {
+    fold2(zip_with2(a, b, Mul::mul), Add::add)
+}
+pub fn dot3<T: Float>(a: Vector3<T>, b: Vector3<T>) -> T {
+    fold3(zip_with3(a, b, Mul::mul), Add::add)
+}
+pub fn dot4<T: Float>(a: Vector4<T>, b: Vector4<T>) -> T {
+    fold4(zip_with4(a, b, Mul::mul), Add::add)
+}
 
-pub fn const2<T: Copy>(x: T) -> Vector2<T> { [x, x] }
-pub fn const3<T: Copy>(x: T) -> Vector3<T> { [x, x, x] }
-pub fn const4<T: Copy>(x: T) -> Vector4<T> { [x, x, x, x] }
+pub fn const2<T: Copy>(x: T) -> Vector2<T> {
+    [x, x]
+}
+pub fn const3<T: Copy>(x: T) -> Vector3<T> {
+    [x, x, x]
+}
+pub fn const4<T: Copy>(x: T) -> Vector4<T> {
+    [x, x, x, x]
+}
 
-pub fn one2<T: Copy + NumCast>() -> Vector2<T> { cast2(const2(1)) }
-pub fn one3<T: Copy + NumCast>() -> Vector3<T> { cast3(const3(1)) }
-pub fn one4<T: Copy + NumCast>() -> Vector4<T> { cast4(const4(1)) }
+pub fn one2<T: Copy + NumCast>() -> Vector2<T> {
+    cast2(const2(1))
+}
+pub fn one3<T: Copy + NumCast>() -> Vector3<T> {
+    cast3(const3(1))
+}
+pub fn one4<T: Copy + NumCast>() -> Vector4<T> {
+    cast4(const4(1))
+}
 
-pub fn cast2<T: NumCast + Copy, U: NumCast + Copy>(x: Point2<T>) -> Point2<U> { map2(x, cast) }
-pub fn cast3<T: NumCast + Copy, U: NumCast + Copy>(x: Point3<T>) -> Point3<U> { map3(x, cast) }
-pub fn cast4<T: NumCast + Copy, U: NumCast + Copy>(x: Point4<T>) -> Point4<U> { map4(x, cast) }
+pub fn cast2<T, U>(x: Point2<T>) -> Point2<U>
+    where T: NumCast + Copy,
+          U: NumCast + Copy,
+{
+    map2(x, cast)
+}
+pub fn cast3<T, U>(x: Point3<T>) -> Point3<U>
+    where T: NumCast + Copy,
+          U: NumCast + Copy,
+{
+    map3(x, cast)
+}
+pub fn cast4<T, U>(x: Point4<T>) -> Point4<U>
+    where T: NumCast + Copy,
+          U: NumCast + Copy,
+{
+    map4(x, cast)
+}

--- a/src/open_simplex.rs
+++ b/src/open_simplex.rs
@@ -17,9 +17,9 @@
 //! http://uniblock.tumblr.com/post/97868843242/noise
 
 use num_traits::Float;
-use std::ops::{Add};
+use std::ops::Add;
 
-use {gradient, math, PermutationTable};
+use {PermutationTable, gradient, math};
 
 const STRETCH_CONSTANT_2D: f64 = -0.211324865405187; //(1/sqrt(2+1)-1)/2;
 const SQUISH_CONSTANT_2D: f64 = 0.366025403784439; //(sqrt(2+1)-1)/2;
@@ -36,7 +36,12 @@ const NORM_CONSTANT_4D: f32 = 1.0 / 6.8699090070956625;
 ///
 /// This is a slower but higher quality form of gradient noise than `noise::perlin2`.
 pub fn open_simplex2<T: Float>(perm_table: &PermutationTable, point: &::Point2<T>) -> T {
-    fn gradient<T: Float>(perm_table: &PermutationTable, xs_floor: T, ys_floor: T, dx: T, dy: T) -> T {
+    fn gradient<T: Float>(perm_table: &PermutationTable,
+                          xs_floor: T,
+                          ys_floor: T,
+                          dx: T,
+                          dy: T)
+                          -> T {
         let zero: T = math::cast(0);
 
         let attn = math::cast::<_, T>(2.0_f64) - dx * dx - dy * dy;
@@ -49,8 +54,8 @@ pub fn open_simplex2<T: Float>(perm_table: &PermutationTable, point: &::Point2<T
         }
     }
 
-    let zero: T = math::cast(0);
-    let one: T = math::cast(1);
+    let zero = T::zero();
+    let one = T::one();
     let squish_constant: T = math::cast(SQUISH_CONSTANT_2D);
 
     // Place input coordinates onto grid.
@@ -118,12 +123,22 @@ pub fn open_simplex2<T: Float>(perm_table: &PermutationTable, point: &::Point2<T
 ///
 /// This is a slower but higher quality form of gradient noise than `noise::perlin3`.
 pub fn open_simplex3<T: Float>(perm_table: &PermutationTable, point: &::Point3<T>) -> T {
-    fn gradient<T: Float>(perm_table: &PermutationTable, xs_floor: T, ys_floor: T, zs_floor: T, dx: T, dy: T, dz: T) -> T {
+    fn gradient<T: Float>(perm_table: &PermutationTable,
+                          xs_floor: T,
+                          ys_floor: T,
+                          zs_floor: T,
+                          dx: T,
+                          dy: T,
+                          dz: T)
+                          -> T {
         let zero: T = math::cast(0);
 
         let attn = math::cast::<_, T>(2.0_f64) - dx * dx - dy * dy - dz * dz;
         if attn > zero {
-            let index = perm_table.get3::<isize>([math::cast(xs_floor), math::cast(ys_floor), math::cast(zs_floor)]);
+            let index =
+                perm_table.get3::<isize>([math::cast(xs_floor),
+                                          math::cast(ys_floor),
+                                          math::cast(zs_floor)]);
             let vec = gradient::get3::<T>(index);
             math::pow4(attn) * (dx * vec[0] + dy * vec[1] + dz * vec[2])
         } else {
@@ -131,8 +146,8 @@ pub fn open_simplex3<T: Float>(perm_table: &PermutationTable, point: &::Point3<T
         }
     }
 
-    let zero: T = math::cast(0);
-    let one: T = math::cast(1);
+    let zero = T::zero();
+    let one = T::one();
     let two: T = math::cast(2);
     let squish_constant: T = math::cast(SQUISH_CONSTANT_3D);
 
@@ -268,7 +283,10 @@ pub fn open_simplex3<T: Float>(perm_table: &PermutationTable, point: &::Point3<T
 /// This is a slower but higher quality form of gradient noise than
 /// `noise::perlin4`.
 pub fn open_simplex4<T: Float>(perm_table: &PermutationTable, point: &math::Point4<T>) -> T {
-    fn gradient<T: Float>(perm_table: &PermutationTable, vertex: &math::Point4<T>, pos: &math::Point4<T>) -> T {
+    fn gradient<T: Float>(perm_table: &PermutationTable,
+                          vertex: &math::Point4<T>,
+                          pos: &math::Point4<T>)
+                          -> T {
         let zero = T::zero();
         let attn = math::cast::<_, T>(2.0_f64) - math::dot4(*pos, *pos);
         if attn > zero {
@@ -323,12 +341,11 @@ pub fn open_simplex4<T: Float>(perm_table: &PermutationTable, point: &math::Poin
         let pos1;
         {
             let vertex = math::add4(stretched_floor, [one, zero, zero, zero]);
-            pos1 = math::sub4(pos0, [
-                one + squish_constant,
-                squish_constant,
-                squish_constant,
-                squish_constant
-            ]);
+            pos1 = math::sub4(pos0,
+                              [one + squish_constant,
+                               squish_constant,
+                               squish_constant,
+                               squish_constant]);
             value = value + gradient(perm_table, &vertex, &pos1);
         }
 
@@ -336,12 +353,7 @@ pub fn open_simplex4<T: Float>(perm_table: &PermutationTable, point: &math::Poin
         let pos2;
         {
             let vertex = math::add4(stretched_floor, [zero, one, zero, zero]);
-            pos2 = [
-                pos1[0] + one,
-                pos1[1] - one,
-                pos1[2],
-                pos1[3]
-            ];
+            pos2 = [pos1[0] + one, pos1[1] - one, pos1[2], pos1[3]];
             value = value + gradient(perm_table, &vertex, &pos2);
         }
 
@@ -349,12 +361,7 @@ pub fn open_simplex4<T: Float>(perm_table: &PermutationTable, point: &math::Poin
         let pos3;
         {
             let vertex = math::add4(stretched_floor, [zero, zero, one, zero]);
-            pos3 = [
-                pos2[0],
-                pos1[1],
-                pos1[2] - one,
-                pos1[3]
-            ];
+            pos3 = [pos2[0], pos1[1], pos1[2] - one, pos1[3]];
             value = value + gradient(perm_table, &vertex, &pos3);
         }
 
@@ -362,12 +369,7 @@ pub fn open_simplex4<T: Float>(perm_table: &PermutationTable, point: &math::Poin
         let pos4;
         {
             let vertex = math::add4(stretched_floor, [zero, zero, zero, one]);
-            pos4 = [
-                pos2[0],
-                pos1[1],
-                pos1[2],
-                pos1[3] - one
-            ];
+            pos4 = [pos2[0], pos1[1], pos1[2], pos1[3] - one];
             value = value + gradient(perm_table, &vertex, &pos4);
         }
     } else if region_sum >= three {
@@ -378,12 +380,11 @@ pub fn open_simplex4<T: Float>(perm_table: &PermutationTable, point: &math::Poin
         let pos4;
         {
             let vertex = math::add4(stretched_floor, [one, one, one, zero]);
-            pos4 = math::sub4(pos0, [
-                one + squish_constant_3,
-                one + squish_constant_3,
-                one + squish_constant_3,
-                squish_constant_3
-            ]);
+            pos4 = math::sub4(pos0,
+                              [one + squish_constant_3,
+                               one + squish_constant_3,
+                               one + squish_constant_3,
+                               squish_constant_3]);
             value = value + gradient(perm_table, &vertex, &pos4);
         }
 
@@ -391,12 +392,7 @@ pub fn open_simplex4<T: Float>(perm_table: &PermutationTable, point: &math::Poin
         let pos3;
         {
             let vertex = math::add4(stretched_floor, [one, one, zero, one]);
-            pos3 = [
-                pos4[0],
-                pos4[1],
-                pos4[2] + one,
-                pos4[3] - one
-            ];
+            pos3 = [pos4[0], pos4[1], pos4[2] + one, pos4[3] - one];
             value = value + gradient(perm_table, &vertex, &pos3);
         }
 
@@ -404,12 +400,7 @@ pub fn open_simplex4<T: Float>(perm_table: &PermutationTable, point: &math::Poin
         let pos2;
         {
             let vertex = math::add4(stretched_floor, [one, zero, one, one]);
-            pos2 = [
-                pos4[0],
-                pos4[1] + one,
-                pos4[2],
-                pos3[3]
-            ];
+            pos2 = [pos4[0], pos4[1] + one, pos4[2], pos3[3]];
             value = value + gradient(perm_table, &vertex, &pos2);
         }
 
@@ -417,12 +408,7 @@ pub fn open_simplex4<T: Float>(perm_table: &PermutationTable, point: &math::Poin
         let pos1;
         {
             let vertex = math::add4(stretched_floor, [zero, one, one, one]);
-            pos1 = [
-                pos0[0] - squish_constant_3,
-                pos4[1],
-                pos4[2],
-                pos3[3]
-            ];
+            pos1 = [pos0[0] - squish_constant_3, pos4[1], pos4[2], pos3[3]];
             value = value + gradient(perm_table, &vertex, &pos1);
         }
 
@@ -442,12 +428,11 @@ pub fn open_simplex4<T: Float>(perm_table: &PermutationTable, point: &math::Poin
         let pos1;
         {
             let vertex = math::add4(stretched_floor, [one, zero, zero, zero]);
-            pos1 = math::sub4(pos0, [
-                one + squish_constant,
-                squish_constant,
-                squish_constant,
-                squish_constant
-            ]);
+            pos1 = math::sub4(pos0,
+                              [one + squish_constant,
+                               squish_constant,
+                               squish_constant,
+                               squish_constant]);
             value = value + gradient(perm_table, &vertex, &pos1);
         }
 
@@ -455,12 +440,7 @@ pub fn open_simplex4<T: Float>(perm_table: &PermutationTable, point: &math::Poin
         let pos2;
         {
             let vertex = math::add4(stretched_floor, [zero, one, zero, zero]);
-            pos2 = [
-                pos1[0] + one,
-                pos1[1] - one,
-                pos1[2],
-                pos1[3]
-            ];
+            pos2 = [pos1[0] + one, pos1[1] - one, pos1[2], pos1[3]];
             value = value + gradient(perm_table, &vertex, &pos2);
         }
 
@@ -468,12 +448,7 @@ pub fn open_simplex4<T: Float>(perm_table: &PermutationTable, point: &math::Poin
         let pos3;
         {
             let vertex = math::add4(stretched_floor, [zero, zero, one, zero]);
-            pos3 = [
-                pos2[0],
-                pos1[1],
-                pos1[2] - one,
-                pos1[3]
-            ];
+            pos3 = [pos2[0], pos1[1], pos1[2] - one, pos1[3]];
             value = value + gradient(perm_table, &vertex, &pos3);
         }
 
@@ -481,12 +456,7 @@ pub fn open_simplex4<T: Float>(perm_table: &PermutationTable, point: &math::Poin
         let pos4;
         {
             let vertex = math::add4(stretched_floor, [zero, zero, zero, one]);
-            pos4 = [
-                pos2[0],
-                pos1[1],
-                pos1[2],
-                pos1[3] - one
-            ];
+            pos4 = [pos2[0], pos1[1], pos1[2], pos1[3] - one];
             value = value + gradient(perm_table, &vertex, &pos4);
         }
 
@@ -494,12 +464,10 @@ pub fn open_simplex4<T: Float>(perm_table: &PermutationTable, point: &math::Poin
         let pos5;
         {
             let vertex = math::add4(stretched_floor, [one, one, zero, zero]);
-            pos5 = [
-                pos1[0] - squish_constant,
-                pos2[1] - squish_constant,
-                pos1[2] - squish_constant,
-                pos1[3] - squish_constant
-            ];
+            pos5 = [pos1[0] - squish_constant,
+                    pos2[1] - squish_constant,
+                    pos1[2] - squish_constant,
+                    pos1[3] - squish_constant];
             value = value + gradient(perm_table, &vertex, &pos5);
         }
 
@@ -507,12 +475,7 @@ pub fn open_simplex4<T: Float>(perm_table: &PermutationTable, point: &math::Poin
         let pos6;
         {
             let vertex = math::add4(stretched_floor, [one, zero, one, zero]);
-            pos6 = [
-                pos5[0],
-                pos5[1] + one,
-                pos5[2] - one,
-                pos5[3]
-            ];
+            pos6 = [pos5[0], pos5[1] + one, pos5[2] - one, pos5[3]];
             value = value + gradient(perm_table, &vertex, &pos6);
         }
 
@@ -520,12 +483,7 @@ pub fn open_simplex4<T: Float>(perm_table: &PermutationTable, point: &math::Poin
         let pos7;
         {
             let vertex = math::add4(stretched_floor, [one, zero, zero, one]);
-            pos7 = [
-                pos5[0],
-                pos6[1],
-                pos5[2],
-                pos5[3] - one
-            ];
+            pos7 = [pos5[0], pos6[1], pos5[2], pos5[3] - one];
             value = value + gradient(perm_table, &vertex, &pos7);
         }
 
@@ -533,12 +491,7 @@ pub fn open_simplex4<T: Float>(perm_table: &PermutationTable, point: &math::Poin
         let pos8;
         {
             let vertex = math::add4(stretched_floor, [zero, one, one, zero]);
-            pos8 = [
-                pos5[0] + one,
-                pos5[1],
-                pos6[2],
-                pos5[3]
-            ];
+            pos8 = [pos5[0] + one, pos5[1], pos6[2], pos5[3]];
             value = value + gradient(perm_table, &vertex, &pos8);
         }
 
@@ -546,12 +499,7 @@ pub fn open_simplex4<T: Float>(perm_table: &PermutationTable, point: &math::Poin
         let pos9;
         {
             let vertex = math::add4(stretched_floor, [zero, one, zero, one]);
-            pos9 = [
-                pos8[0],
-                pos5[1],
-                pos5[2],
-                pos7[3]
-            ];
+            pos9 = [pos8[0], pos5[1], pos5[2], pos7[3]];
             value = value + gradient(perm_table, &vertex, &pos9);
         }
 
@@ -559,12 +507,7 @@ pub fn open_simplex4<T: Float>(perm_table: &PermutationTable, point: &math::Poin
         let pos10;
         {
             let vertex = math::add4(stretched_floor, [zero, zero, one, one]);
-            pos10 = [
-                pos8[0],
-                pos6[1],
-                pos6[2],
-                pos7[3]
-            ];
+            pos10 = [pos8[0], pos6[1], pos6[2], pos7[3]];
             value = value + gradient(perm_table, &vertex, &pos10);
         }
     } else {
@@ -575,12 +518,11 @@ pub fn open_simplex4<T: Float>(perm_table: &PermutationTable, point: &math::Poin
         let pos4;
         {
             let vertex = math::add4(stretched_floor, [one, one, one, zero]);
-            pos4 = math::sub4(pos0, [
-                one + squish_constant_3,
-                one + squish_constant_3,
-                one + squish_constant_3,
-                squish_constant_3
-            ]);
+            pos4 = math::sub4(pos0,
+                              [one + squish_constant_3,
+                               one + squish_constant_3,
+                               one + squish_constant_3,
+                               squish_constant_3]);
             value = value + gradient(perm_table, &vertex, &pos4);
         }
 
@@ -588,12 +530,7 @@ pub fn open_simplex4<T: Float>(perm_table: &PermutationTable, point: &math::Poin
         let pos3;
         {
             let vertex = math::add4(stretched_floor, [one, one, zero, one]);
-            pos3 = [
-                pos4[0],
-                pos4[1],
-                pos4[2] + one,
-                pos4[3] - one
-            ];
+            pos3 = [pos4[0], pos4[1], pos4[2] + one, pos4[3] - one];
             value = value + gradient(perm_table, &vertex, &pos3);
         }
 
@@ -601,12 +538,7 @@ pub fn open_simplex4<T: Float>(perm_table: &PermutationTable, point: &math::Poin
         let pos2;
         {
             let vertex = math::add4(stretched_floor, [one, zero, one, one]);
-            pos2 = [
-                pos4[0],
-                pos4[1] + one,
-                pos4[2],
-                pos3[3]
-            ];
+            pos2 = [pos4[0], pos4[1] + one, pos4[2], pos3[3]];
             value = value + gradient(perm_table, &vertex, &pos2);
         }
 
@@ -614,12 +546,7 @@ pub fn open_simplex4<T: Float>(perm_table: &PermutationTable, point: &math::Poin
         let pos1;
         {
             let vertex = math::add4(stretched_floor, [zero, one, one, one]);
-            pos1 = [
-                pos4[0] + one,
-                pos4[1],
-                pos4[2],
-                pos3[3]
-            ];
+            pos1 = [pos4[0] + one, pos4[1], pos4[2], pos3[3]];
             value = value + gradient(perm_table, &vertex, &pos1);
         }
 
@@ -627,12 +554,10 @@ pub fn open_simplex4<T: Float>(perm_table: &PermutationTable, point: &math::Poin
         let pos5;
         {
             let vertex = math::add4(stretched_floor, [one, one, zero, zero]);
-            pos5 = [
-                pos4[0] + squish_constant,
-                pos4[1] + squish_constant,
-                pos3[2] + squish_constant,
-                pos4[3] + squish_constant
-            ];
+            pos5 = [pos4[0] + squish_constant,
+                    pos4[1] + squish_constant,
+                    pos3[2] + squish_constant,
+                    pos4[3] + squish_constant];
             value = value + gradient(perm_table, &vertex, &pos5);
         }
 
@@ -640,12 +565,7 @@ pub fn open_simplex4<T: Float>(perm_table: &PermutationTable, point: &math::Poin
         let pos6;
         {
             let vertex = math::add4(stretched_floor, [one, zero, one, zero]);
-            pos6 = [
-                pos5[0],
-                pos5[1] + one,
-                pos5[2] - one,
-                pos5[3]
-            ];
+            pos6 = [pos5[0], pos5[1] + one, pos5[2] - one, pos5[3]];
             value = value + gradient(perm_table, &vertex, &pos6);
         }
 
@@ -653,12 +573,7 @@ pub fn open_simplex4<T: Float>(perm_table: &PermutationTable, point: &math::Poin
         let pos7;
         {
             let vertex = math::add4(stretched_floor, [one, zero, zero, one]);
-            pos7 = [
-                pos5[0],
-                pos6[1],
-                pos5[2],
-                pos5[3] - one
-            ];
+            pos7 = [pos5[0], pos6[1], pos5[2], pos5[3] - one];
             value = value + gradient(perm_table, &vertex, &pos7);
         }
 
@@ -666,12 +581,7 @@ pub fn open_simplex4<T: Float>(perm_table: &PermutationTable, point: &math::Poin
         let pos8;
         {
             let vertex = math::add4(stretched_floor, [zero, one, one, zero]);
-            pos8 = [
-                pos5[0] + one,
-                pos5[1],
-                pos6[2],
-                pos5[3]
-            ];
+            pos8 = [pos5[0] + one, pos5[1], pos6[2], pos5[3]];
             value = value + gradient(perm_table, &vertex, &pos8);
         }
 
@@ -679,12 +589,7 @@ pub fn open_simplex4<T: Float>(perm_table: &PermutationTable, point: &math::Poin
         let pos9;
         {
             let vertex = math::add4(stretched_floor, [zero, one, zero, one]);
-            pos9 = [
-                pos8[0],
-                pos5[1],
-                pos5[2],
-                pos7[3]
-            ];
+            pos9 = [pos8[0], pos5[1], pos5[2], pos7[3]];
             value = value + gradient(perm_table, &vertex, &pos9);
         }
 
@@ -692,12 +597,7 @@ pub fn open_simplex4<T: Float>(perm_table: &PermutationTable, point: &math::Poin
         let pos10;
         {
             let vertex = math::add4(stretched_floor, [zero, zero, one, one]);
-            pos10 = [
-                pos8[0],
-                pos6[1],
-                pos6[2],
-                pos7[3]
-            ];
+            pos10 = [pos8[0], pos6[1], pos6[2], pos7[3]];
             value = value + gradient(perm_table, &vertex, &pos10);
         }
     }

--- a/src/perlin.rs
+++ b/src/perlin.rs
@@ -14,12 +14,15 @@
 
 use num_traits::Float;
 
-use {gradient, math, PermutationTable};
+use {PermutationTable, gradient, math};
 
 /// 2-dimensional perlin noise
 pub fn perlin2<T: Float>(perm_table: &PermutationTable, point: &math::Point2<T>) -> T {
     #[inline(always)]
-    fn surflet<T: Float>(perm_table: &PermutationTable, corner: math::Point2<isize>, distance: math::Vector2<T>) -> T {
+    fn surflet<T: Float>(perm_table: &PermutationTable,
+                         corner: math::Point2<isize>,
+                         distance: math::Vector2<T>)
+                         -> T {
         let attn = T::one() - math::dot2(distance, distance);
         if attn > T::zero() {
             math::pow4(attn) * math::dot2(distance, gradient::get2(perm_table.get2(corner)))
@@ -28,7 +31,7 @@ pub fn perlin2<T: Float>(perm_table: &PermutationTable, point: &math::Point2<T>)
         }
     }
 
-    let floored = math::map2(*point, Float::floor);
+    let floored = math::map2(*point, T::floor);
     let near_corner = math::map2(floored, math::cast);
     let far_corner = math::add2(near_corner, math::one2());
     let near_distance = math::sub2(*point, floored);
@@ -54,7 +57,10 @@ pub fn perlin2<T: Float>(perm_table: &PermutationTable, point: &math::Point2<T>)
 /// 3-dimensional perlin noise
 pub fn perlin3<T: Float>(perm_table: &PermutationTable, point: &math::Point3<T>) -> T {
     #[inline(always)]
-    fn surflet<T: Float>(perm_table: &PermutationTable, corner: math::Point3<isize>, distance: math::Vector3<T>) -> T {
+    fn surflet<T: Float>(perm_table: &PermutationTable,
+                         corner: math::Point3<isize>,
+                         distance: math::Vector3<T>)
+                         -> T {
         let attn = T::one() - math::dot3(distance, distance);
         if attn > T::zero() {
             math::pow4(attn) * math::dot3(distance, gradient::get3(perm_table.get3(corner)))
@@ -63,7 +69,7 @@ pub fn perlin3<T: Float>(perm_table: &PermutationTable, point: &math::Point3<T>)
         }
     }
 
-    let floored = math::map3(*point, Float::floor);
+    let floored = math::map3(*point, T::floor);
     let near_corner = math::map3(floored, math::cast);
     let far_corner = math::add3(near_corner, math::one3());
     let near_distance = math::sub3(*point, floored);
@@ -101,7 +107,10 @@ pub fn perlin3<T: Float>(perm_table: &PermutationTable, point: &math::Point3<T>)
 /// 4-dimensional perlin noise
 pub fn perlin4<T: Float>(perm_table: &PermutationTable, point: &math::Point4<T>) -> T {
     #[inline(always)]
-    fn surflet<T: Float>(perm_table: &PermutationTable, corner: math::Point4<isize>, distance: math::Vector4<T>) -> T {
+    fn surflet<T: Float>(perm_table: &PermutationTable,
+                         corner: math::Point4<isize>,
+                         distance: math::Vector4<T>)
+                         -> T {
         let attn = T::one() - math::dot4(distance, distance);
         if attn > T::zero() {
             math::pow4(attn) * math::dot4(distance, gradient::get4(perm_table.get4(corner)))
@@ -110,7 +119,7 @@ pub fn perlin4<T: Float>(perm_table: &PermutationTable, point: &math::Point4<T>)
         }
     }
 
-    let floored = math::map4(*point, Float::floor);
+    let floored = math::map4(*point, T::floor);
     let near_corner = math::map4(floored, math::cast);
     let far_corner = math::add4(near_corner, math::one4());
     let near_distance = math::sub4(*point, floored);

--- a/src/permutationtable.rs
+++ b/src/permutationtable.rs
@@ -14,7 +14,7 @@
 
 // TODO: Use PrimInt + Signed instead of SignedInt + NumCast once num has
 // PrimInt implementations
-use num_traits::{NumCast,Signed,PrimInt};
+use num_traits::{NumCast, PrimInt, Signed};
 use rand::{Rand, Rng, SeedableRng, XorShiftRng};
 use std::fmt;
 
@@ -60,15 +60,17 @@ impl Rand for PermutationTable {
     /// # }
     /// ```
     fn rand<R: Rng>(rng: &mut R) -> PermutationTable {
-        let mut seq: Vec<u8> = (0 .. TABLE_SIZE).map(|x| x as u8).collect();
+        let mut seq: Vec<u8> = (0..TABLE_SIZE).map(|x| x as u8).collect();
         rng.shuffle(&mut *seq);
 
-        // It's unfortunate that this double-initializes the array, but Rust doesn't currently provide a
-        // clean way to do this in one pass. Hopefully won't matter, as Seed creation will usually be a
-        // one-time event.
+        // It's unfortunate that this double-initializes the array, but Rust
+        // doesn't currently provide a clean way to do this in one pass. Hopefully
+        // it won't matter, as Seed creation will usually be a one-time event.
         let mut perm_table = PermutationTable { values: [0; TABLE_SIZE] };
         let seq_it = seq.iter();
-        for (x, y) in perm_table.values.iter_mut().zip(seq_it) { *x = *y }
+        for (x, y) in perm_table.values.iter_mut().zip(seq_it) {
+            *x = *y
+        }
         perm_table
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -14,7 +14,7 @@
 
 use num_traits::Float;
 
-use {math, PermutationTable};
+use {PermutationTable, math};
 
 /// Linearly interpolate values.
 fn lerp<T: Float>(a: T, b: T, x: T) -> T {
@@ -30,13 +30,14 @@ fn smoothstep<T: Float>(x: T) -> T {
 }
 
 /// 2-dimensional value noise
+#[cfg_attr(rustfmt, rustfmt_skip)]
 pub fn value2<T: Float>(perm_table: &PermutationTable, point: &math::Point2<T>) -> T {
     #[inline(always)]
     fn get<T: Float>(perm_table: &PermutationTable, corner: math::Point2<isize>) -> T {
         math::cast::<_, T>(perm_table.get2(corner)) * math::cast(1.0 / 255.0)
     }
 
-    let floored = math::map2(*point, Float::floor);
+    let floored = math::map2(*point, T::floor);
     let near_corner = math::map2(floored, math::cast);
     let far_corner = math::add2(near_corner, math::one2());
     let weight = math::map2(math::sub2(*point, floored), smoothstep);
@@ -54,13 +55,14 @@ pub fn value2<T: Float>(perm_table: &PermutationTable, point: &math::Point2<T>) 
 }
 
 /// 3-dimensional value noise
+#[cfg_attr(rustfmt, rustfmt_skip)]
 pub fn value3<T: Float>(perm_table: &PermutationTable, point: &math::Point3<T>) -> T {
     #[inline(always)]
     fn get<T: Float>(perm_table: &PermutationTable, corner: math::Point3<isize>) -> T {
         math::cast::<_, T>(perm_table.get3(corner)) * math::cast(1.0 / 255.0)
     }
 
-    let floored = math::map3(*point, Float::floor);
+    let floored = math::map3(*point, T::floor);
     let near_corner = math::map3(floored, math::cast);
     let far_corner = math::add3(near_corner, math::one3());
     let weight = math::map3(math::sub3(*point, floored), smoothstep);
@@ -86,13 +88,14 @@ pub fn value3<T: Float>(perm_table: &PermutationTable, point: &math::Point3<T>) 
 }
 
 /// 4-dimensional value noise
+#[cfg_attr(rustfmt, rustfmt_skip)]
 pub fn value4<T: Float>(perm_table: &PermutationTable, point: &math::Point4<T>) -> T {
     #[inline(always)]
     fn get<T: Float>(perm_table: &PermutationTable, corner: math::Point4<isize>) -> T {
         math::cast::<_, T>(perm_table.get4(corner)) * math::cast(1.0 / 255.0)
     }
 
-    let floored = math::map4(*point, Float::floor);
+    let floored = math::map4(*point, T::floor);
     let near_corner = math::map4(floored, math::cast);
     let far_corner = math::add4(near_corner, math::one4());
     let weight = math::map4(math::sub4(*point, floored), smoothstep);


### PR DESCRIPTION
This just moves the "Generated ..." messages out of the examples to avoid repeating the same thing in each example.