### PR TITLE
Move "Generated ..." messages out of the examples

### DIFF
--- a/examples/brownian.rs
+++ b/examples/brownian.rs
@@ -24,7 +24,6 @@ fn main() {
     debug::render_png("brownian2.png", &PermutationTable::new(0), 1024, 1024, brownian2_for_image);
     debug::render_png("brownian3.png", &PermutationTable::new(0), 1024, 1024, brownian3_for_image);
     debug::render_png("brownian4.png", &PermutationTable::new(0), 1024, 1024, brownian4_for_image);
-    println!("\nGenerated brownian2.png, brownian3.png and brownian4.png");
 }
 
 fn brownian2_for_image(perm_table: &PermutationTable, point: &Point2<f64>) -> f64 {

--- a/examples/cell_manhattan.rs
+++ b/examples/cell_manhattan.rs
@@ -24,7 +24,6 @@ fn main() {
     debug::render_png("cell2_manhattan.png", &PermutationTable::new(0), 1024, 1024, scaled_cell2_manhattan);
     debug::render_png("cell3_manhattan.png", &PermutationTable::new(0), 1024, 1024, scaled_cell3_manhattan);
     debug::render_png("cell4_manhattan.png", &PermutationTable::new(0), 1024, 1024, scaled_cell4_manhattan);
-    println!("\nGenerated cell2_manhattan.png, cell3_manhattan.png and cell4_manhattan.png");
 }
 
 fn scaled_cell2_manhattan(perm_table: &PermutationTable, point: &Point2<f64>) -> f64 {

--- a/examples/cell_manhattan_inv.rs
+++ b/examples/cell_manhattan_inv.rs
@@ -24,7 +24,6 @@ fn main() {
     debug::render_png("cell2_manhattan_inv.png", &PermutationTable::new(0), 1024, 1024, scaled_cell2_manhattan_inv);
     debug::render_png("cell3_manhattan_inv.png", &PermutationTable::new(0), 1024, 1024, scaled_cell3_manhattan_inv);
     debug::render_png("cell4_manhattan_inv.png", &PermutationTable::new(0), 1024, 1024, scaled_cell4_manhattan_inv);
-    println!("\nGenerated cell2_manhattan_inv.png, cell3_manhattan_inv.png and cell4_manhattan_inv.png");
 }
 
 fn scaled_cell2_manhattan_inv(perm_table: &PermutationTable, point: &Point2<f64>) -> f64 {

--- a/examples/cell_manhattan_value.rs
+++ b/examples/cell_manhattan_value.rs
@@ -24,7 +24,6 @@ fn main() {
     debug::render_png("cell2_manhattan_value.png", &PermutationTable::new(0), 1024, 1024, scaled_cell2_manhattan_value);
     debug::render_png("cell3_manhattan_value.png", &PermutationTable::new(0), 1024, 1024, scaled_cell3_manhattan_value);
     debug::render_png("cell4_manhattan_value.png", &PermutationTable::new(0), 1024, 1024, scaled_cell4_manhattan_value);
-    println!("\nGenerated cell2_manhattan_value.png, cell3_manhattan_value.png and cell4_manhattan_value.png");
 }
 
 fn scaled_cell2_manhattan_value(perm_table: &PermutationTable, point: &Point2<f64>) -> f64 {

--- a/examples/cell_range.rs
+++ b/examples/cell_range.rs
@@ -24,7 +24,6 @@ fn main() {
     debug::render_png("cell2_range.png", &PermutationTable::new(0), 1024, 1024, scaled_cell2_range);
     debug::render_png("cell3_range.png", &PermutationTable::new(0), 1024, 1024, scaled_cell3_range);
     debug::render_png("cell4_range.png", &PermutationTable::new(0), 1024, 1024, scaled_cell4_range);
-    println!("\nGenerated cell2_range.png, cell3_range.png and cell4_range.png");
 }
 
 fn scaled_cell2_range(perm_table: &PermutationTable, point: &Point2<f64>) -> f64 {

--- a/examples/cell_range_inv.rs
+++ b/examples/cell_range_inv.rs
@@ -24,7 +24,6 @@ fn main() {
     debug::render_png("cell2_range_inv.png", &PermutationTable::new(0), 1024, 1024, scaled_cell2_range_inv);
     debug::render_png("cell3_range_inv.png", &PermutationTable::new(0), 1024, 1024, scaled_cell3_range_inv);
     debug::render_png("cell4_range_inv.png", &PermutationTable::new(0), 1024, 1024, scaled_cell4_range_inv);
-    println!("\nGenerated cell2_range_inv.png, cell3_range_inv.png and cell4_range_inv.png");
 }
 
 fn scaled_cell2_range_inv(perm_table: &PermutationTable, point: &Point2<f64>) -> f64 {

--- a/examples/cell_value.rs
+++ b/examples/cell_value.rs
@@ -24,7 +24,6 @@ fn main() {
     debug::render_png("cell2_value.png", &PermutationTable::new(0), 1024, 1024, scaled_cell2_value);
     debug::render_png("cell3_value.png", &PermutationTable::new(0), 1024, 1024, scaled_cell3_value);
     debug::render_png("cell4_value.png", &PermutationTable::new(0), 1024, 1024, scaled_cell4_value);
-    println!("\nGenerated cell2_value.png, cell3_value.png and cell4_value.png");
 }
 
 fn scaled_cell2_value(perm_table: &PermutationTable, point: &Point2<f64>) -> f64 {

--- a/examples/debug/mod.rs
+++ b/examples/debug/mod.rs
@@ -46,5 +46,11 @@ pub fn render_png<T, F>(filename: &str, perm_table: &noise::PermutationTable, wi
         }
     }
 
-    let _ = image::save_buffer(&Path::new(filename), &*pixels, width, height, image::Gray(8));
+    let _ = image::save_buffer(&Path::new(filename),
+                               &*pixels,
+                               width,
+                               height,
+                               image::Gray(8));
+
+    println!("\nGenerated {}", filename);
 }

--- a/examples/perlin.rs
+++ b/examples/perlin.rs
@@ -24,7 +24,6 @@ fn main() {
     debug::render_png("perlin2.png", &PermutationTable::new(0), 1024, 1024, scaled_perlin2);
     debug::render_png("perlin3.png", &PermutationTable::new(0), 1024, 1024, scaled_perlin3);
     debug::render_png("perlin4.png", &PermutationTable::new(0), 1024, 1024, scaled_perlin4);
-    println!("\nGenerated perlin2.png, perlin3.png and perlin4.png");
 }
 
 fn scaled_perlin2(perm_table: &PermutationTable, point: &Point2<f64>) -> f64 {

--- a/examples/value.rs
+++ b/examples/value.rs
@@ -24,7 +24,6 @@ fn main() {
     debug::render_png("value2.png", &PermutationTable::new(0), 1024, 1024, scaled_value2);
     debug::render_png("value3.png", &PermutationTable::new(0), 1024, 1024, scaled_value3);
     debug::render_png("value4.png", &PermutationTable::new(0), 1024, 1024, scaled_value4);
-    println!("\nGenerated value2.png, value3.png and value4.png");
 }
 
 fn scaled_value2(perm_table: &PermutationTable, point: &Point2<f64>) -> f64 {


### PR DESCRIPTION
This moves the "Generated ..." messages out of the examples to avoid repeating the same thing in each example.